### PR TITLE
Fix PWA install prompt availability on landing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -195,12 +195,14 @@ export default async function RootLayout({
         <Script id="pwa-install-bridge" strategy="beforeInteractive">{`
           (function(){
             try {
-              var BRIDGE_EVENT_NAME = 'snapmydate:beforeinstallprompt';
+              var BRIDGE_EVENT_NAME = 'envitefy:beforeinstallprompt';
               var w = window;
-              if (!w.__snapInstallBridgeReady) {
-                w.__snapInstallBridgeReady = true;
+              if (!w.__envitefyInstallBridgeReady) {
+                w.__envitefyInstallBridgeReady = true;
+                try { w.__snapInstallBridgeReady = true; } catch {}
                 window.addEventListener('beforeinstallprompt', function(e){
                   try { e.preventDefault && e.preventDefault(); } catch {}
+                  try { w.__envitefyInstallDeferredPrompt = e; } catch {}
                   try { w.__snapInstallDeferredPrompt = e; } catch {}
                   try {
                     var evt;


### PR DESCRIPTION
## Summary
- rename the PWA install bridge event and deferred prompt storage to the Envitefy branding while syncing legacy keys for compatibility
- keep the floating install button visible on the landing page and centralize prompt state handling so both landing and signed-in views behave the same

## Testing
- npm run lint *(fails: repository has pre-existing lint errors in multiple API routes)*

------
https://chatgpt.com/codex/tasks/task_e_68ff6bc5ed04832c91f933bdd2c5c57f