### PR TITLE
Ensure landing page exposes PWA install prompt

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -12,6 +12,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { usePathname } from "next/navigation";
 import { SidebarProvider } from "./sidebar-context";
 import GlobalEventCreate from "./GlobalEventCreate";
 import GlobalSmartSignup from "./GlobalSmartSignup";
@@ -396,6 +397,9 @@ export default function Providers({
   scheduledThemeKey: ThemeKey;
   initialOverride?: ThemeOverride | null;
 }) {
+  const pathname = usePathname();
+  const installStartExpanded = pathname?.startsWith("/landing") ?? false;
+
   return (
     <SessionProvider session={session}>
       <SidebarProvider>
@@ -409,7 +413,7 @@ export default function Providers({
           {children}
           <GlobalEventCreate />
           <GlobalSmartSignup />
-          <PwaInstallButton />
+          <PwaInstallButton startExpanded={installStartExpanded} />
         </ThemeProvider>
       </SidebarProvider>
     </SessionProvider>


### PR DESCRIPTION
## Summary
- auto expand the existing PWA install prompt when visiting `/landing`
- allow the install prompt to accept a `startExpanded` option and remember manual dismissals

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ffd978e9cc832c8513533c5b81790a