### PR TITLE
Prevent landing redirect loop when authenticated

### DIFF
--- a/src/app/landing/LoginHero.tsx
+++ b/src/app/landing/LoginHero.tsx
@@ -2,13 +2,14 @@
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import BackgroundSlider from "@/components/BackgroundSlider";
 import AuthModal from "@/components/auth/AuthModal";
 
 export default function LoginHero() {
   const { status } = useSession();
   const router = useRouter();
+  const pathname = usePathname();
   const [modalOpen, setModalOpen] = useState(false);
   const [mode, setMode] = useState<"login" | "signup">("login");
   const [showReadMore, setShowReadMore] = useState(false);
@@ -120,6 +121,7 @@ export default function LoginHero() {
 
   useEffect(() => {
     if (status !== "authenticated") return;
+    if (pathname === "/") return;
     try {
       if (typeof window !== "undefined") {
         const welcomeFlag = window.localStorage.getItem("welcomeAfterSignup");
@@ -127,7 +129,7 @@ export default function LoginHero() {
       }
     } catch {}
     router.replace("/");
-  }, [status, router]);
+  }, [status, router, pathname]);
 
   // Open modal automatically when `?auth=login` or `?auth=signup` is present and respond to query changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid re-running landing page redirect when already on the home path
- keep the hero slider stable by stopping redundant router replaces

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3f75b1c8832c976550e832ca1417)