### PR TITLE
Fix middleware token secret fallback

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -118,7 +118,10 @@ export async function middleware(req: NextRequest) {
     return ok();
   }
 
-  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+  const secret =
+    process.env.AUTH_SECRET ??
+    process.env.NEXTAUTH_SECRET ??
+    (process.env.NODE_ENV === "production" ? undefined : "dev-build-secret");
   const token = await getToken({ req: req as any, secret });
   let hasSession = Boolean(token);
 


### PR DESCRIPTION
## Summary
- align middleware token decryption with NextAuth by adding the development fallback secret
- ensure authenticated users are detected in middleware so they can be redirected correctly after login

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e462f01e0832caa021d87c720ff07)