### PR TITLE
Show top navigation only for signed-in users

### DIFF
--- a/src/components/navigation/TopNav.tsx
+++ b/src/components/navigation/TopNav.tsx
@@ -81,8 +81,7 @@ export default function TopNav() {
     }
   }, []);
 
-  const isLandingPage = (pathname || "") === "/";
-  const shouldShowNav = status === "authenticated" && !isLandingPage;
+  const shouldShowNav = status === "authenticated";
 
   useEffect(() => {
     if (typeof document === "undefined") return;


### PR DESCRIPTION
## Summary
- show the top navigation whenever the session is authenticated
- keep the bar hidden for users who are not signed in

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e50e8a484832c82e7b4b5eb10728d)