### PR TITLE
Adjust landing mobile logo and show bottom-right Install CTA only when app not installed

### DIFF
--- a/src/app/landing/components/LandingNav.tsx
+++ b/src/app/landing/components/LandingNav.tsx
@@ -44,10 +44,13 @@ export default function LandingNav() {
             : "pt-8 pb-5"
         }`}
       >
-        <div className="max-w-7xl mx-auto px-6 flex items-center justify-between">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 flex items-center justify-between gap-3">
           {/* Logo */}
-          <Link href="/" className="flex items-center gap-2 group">
-            <EnvitefyWordmark className="text-[2.2rem] leading-none transition-transform duration-300 group-hover:scale-105" />
+          <Link
+            href="/"
+            className="group order-2 ml-auto flex min-w-0 items-center justify-end gap-2 md:order-none md:ml-0"
+          >
+            <EnvitefyWordmark className="max-w-full text-[1.65rem] leading-none transition-transform duration-300 group-hover:scale-105 sm:text-[1.85rem] md:text-[2.2rem]" />
           </Link>
 
           {/* Desktop Nav */}
@@ -92,7 +95,7 @@ export default function LandingNav() {
 
           {/* Mobile Toggle */}
           <button
-            className="md:hidden p-2 text-gray-700"
+            className="order-1 md:hidden p-2 text-gray-700"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             aria-label="Toggle menu"
           >

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useMemo,
 } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { SidebarProvider } from "./sidebar-context";
 import GlobalEventCreate from "./GlobalEventCreate";
 import GlobalSmartSignup from "./GlobalSmartSignup";
@@ -84,9 +84,6 @@ export default function Providers({
 }: {
   children: ReactNode;
 }) {
-  const pathname = usePathname();
-  const installStartExpanded = pathname?.startsWith("/landing") ?? false;
-
   return (
     <SessionProvider>
       <SidebarProvider>
@@ -97,7 +94,7 @@ export default function Providers({
           {children}
           <GlobalEventCreate />
           <GlobalSmartSignup />
-          <PwaInstallButton startExpanded={installStartExpanded} />
+          <PwaInstallButton />
         </ThemeProvider>
       </SidebarProvider>
     </SessionProvider>

--- a/src/components/PwaInstallButton.tsx
+++ b/src/components/PwaInstallButton.tsx
@@ -400,6 +400,11 @@ export default function PwaInstallButton({
   const [guidePulse, setGuidePulse] = useState(false);
   const [installedState, setInstalledState] = useState(false);
 
+  const openGuide = useCallback(() => {
+    setWasManuallyClosed(false);
+    setExpanded(true);
+  }, []);
+
   const markInstalled = useCallback(
     (reason: string, meta?: Record<string, unknown>) => {
       setInstalledState(true);
@@ -847,6 +852,65 @@ export default function PwaInstallButton({
     return () => window.clearTimeout(timer);
   }, [guidePulse]);
 
+  const handleInstallAction = useCallback(async () => {
+    const w = window as SnapWindow;
+    const promptEvent =
+      deferredPromptRef.current ?? deferred ?? w.__snapInstallDeferredPrompt ?? null;
+
+    if (promptEvent && typeof promptEvent.prompt === "function") {
+      deferredPromptRef.current = promptEvent;
+      setDeferred(promptEvent);
+      try {
+        pushDebug("install CTA prompt triggered");
+        await promptEvent.prompt();
+        let choice: {
+          outcome: "accepted" | "dismissed";
+          platform: string;
+        } | null = null;
+        try {
+          choice = await (promptEvent as any).userChoice;
+        } catch {
+          choice = null;
+        }
+        pushDebug("install CTA user choice resolved", {
+          outcome: choice?.outcome ?? "unknown",
+          platform: choice?.platform ?? "unknown",
+        });
+        if (choice?.outcome === "accepted") {
+          setShowIosTip(false);
+          setMaybeInstallable(false);
+          setExpanded(false);
+          setHideUi(true);
+        } else {
+          setGuidePulse(true);
+          openGuide();
+        }
+      } catch (error) {
+        pushDebug("install CTA prompt error", {
+          message: error instanceof Error ? error.message : String(error),
+        });
+        setGuidePulse(true);
+        openGuide();
+      } finally {
+        deferredPromptRef.current = null;
+        setDeferred(null);
+        setCanInstall(false);
+        setShowIosTip(false);
+        try {
+          w.__snapInstallDeferredPrompt = null;
+        } catch {}
+      }
+      return;
+    }
+    pushDebug("install CTA prompt missing; switching to fallback");
+    deferredPromptRef.current = null;
+    setDeferred(null);
+    setCanInstall(false);
+    setShowIosTip(false);
+    setGuidePulse(true);
+    openGuide();
+  }, [deferred, openGuide, pushDebug]);
+
   if (shouldHideInstallUi()) return null;
 
   // Additional safety check: hide if running in standalone mode
@@ -906,11 +970,8 @@ export default function PwaInstallButton({
       {!expanded && (
         <button
           type="button"
-          onClick={() => {
-            setWasManuallyClosed(false);
-            setExpanded(true);
-          }}
-          className="flex h-12 w-12 items-center justify-center rounded-full border border-white/70 bg-[linear-gradient(135deg,#6b3cff_0%,#6757ff_40%,#5a7dff_100%)] text-white shadow-[0_20px_40px_rgba(103,87,255,0.35)] transition-all hover:-translate-y-0.5 hover:shadow-[0_24px_44px_rgba(103,87,255,0.42)]"
+          onClick={showInstallCta ? handleInstallAction : openGuide}
+          className="inline-flex h-12 items-center justify-center gap-2 rounded-full border border-white/70 bg-[linear-gradient(135deg,#6b3cff_0%,#6757ff_40%,#5a7dff_100%)] px-4 text-sm font-semibold text-white shadow-[0_20px_40px_rgba(103,87,255,0.35)] transition-all hover:-translate-y-0.5 hover:shadow-[0_24px_44px_rgba(103,87,255,0.42)]"
           aria-label="Open install options"
         >
           <svg
@@ -930,6 +991,7 @@ export default function PwaInstallButton({
               fill="currentColor"
             />
           </svg>
+          <span>Install app</span>
         </button>
       )}
       {expanded && (
@@ -996,73 +1058,7 @@ export default function PwaInstallButton({
               </div>
               {showInstallCta && (
                 <button
-                  onClick={async () => {
-                    const w = window as SnapWindow;
-                    const promptEvent =
-                      deferredPromptRef.current ??
-                      deferred ??
-                      w.__snapInstallDeferredPrompt ??
-                      null;
-
-                    if (promptEvent && typeof promptEvent.prompt === "function") {
-                      deferredPromptRef.current = promptEvent;
-                      setDeferred(promptEvent);
-                      try {
-                        pushDebug("install CTA prompt triggered");
-                        await promptEvent.prompt();
-                        let choice: {
-                          outcome: "accepted" | "dismissed";
-                          platform: string;
-                        } | null = null;
-                        try {
-                          choice = await (promptEvent as any).userChoice;
-                        } catch {
-                          choice = null;
-                        }
-                        pushDebug("install CTA user choice resolved", {
-                          outcome: choice?.outcome ?? "unknown",
-                          platform: choice?.platform ?? "unknown",
-                        });
-                        if (choice?.outcome === "accepted") {
-                          setShowIosTip(false);
-                          setMaybeInstallable(false);
-                          setExpanded(false);
-                          setHideUi(true);
-                        } else {
-                          // Prompt dismissed or unavailable; surface fallback instructions.
-                          setGuidePulse(true);
-                          setExpanded(true);
-                        }
-                      } catch (error) {
-                        pushDebug("install CTA prompt error", {
-                          message:
-                            error instanceof Error
-                              ? error.message
-                              : String(error),
-                        });
-                        setGuidePulse(true);
-                        setExpanded(true);
-                      } finally {
-                        deferredPromptRef.current = null;
-                        setDeferred(null);
-                        setCanInstall(false);
-                        setShowIosTip(false);
-                        try {
-                          w.__snapInstallDeferredPrompt = null;
-                        } catch {}
-                      }
-                      return;
-                    }
-                    pushDebug(
-                      "install CTA prompt missing; switching to fallback"
-                    );
-                    deferredPromptRef.current = null;
-                    setDeferred(null);
-                    setCanInstall(false);
-                    setShowIosTip(false);
-                    setGuidePulse(true);
-                    setExpanded(true);
-                  }}
+                  onClick={handleInstallAction}
                   className="w-full rounded-full bg-[linear-gradient(96deg,#6b3cff_0%,#6757ff_40%,#5a7dff_100%)] px-4 py-3 text-sm font-semibold text-white shadow-[0_16px_30px_rgba(103,87,255,0.3)] transition-all hover:-translate-y-0.5 hover:shadow-[0_20px_34px_rgba(103,87,255,0.35)]"
                 >
                   Install app


### PR DESCRIPTION
### Motivation
- Improve landing-page mobile layout by moving the brand wordmark to the right and reducing its mobile size so the logo fits on small screens. 
- Replace the large landing install instructions panel with a compact bottom-right install CTA when the app is not installed, while preserving platform-specific guidance for fallback installs. 
- Ensure the install CTA is hidden when the app is already installed or running in standalone mode across targeted platforms (`android`, `ios`, `ipados`, `macos`, `windows`).

### Description
- Updated `src/app/landing/components/LandingNav.tsx` to reposition the `EnvitefyWordmark` to the right on mobile and reduce its mobile font-size/constraints (adjusted layout classes and ordering). 
- Removed the landing-specific `startExpanded` wiring by simplifying the `PwaInstallButton` mounting in `src/app/providers.tsx` so the install CTA is controlled by the component itself. 
- Enhanced `src/components/PwaInstallButton.tsx` to: add `openGuide` and `handleInstallAction` handlers; change the collapsed FAB to read `Install app` and trigger the native `beforeinstallprompt` flow when available; fall back to the existing platform-specific instruction card only after native prompt dismissal or when native prompt is missing; preserve detection of installed/standalone state and hide the CTA accordingly; adjust button styling to space label+icon for mobile. 

### Testing
- Ran `git diff --check` successfully to validate no whitespace/index issues. 
- Ran `npx eslint src/app/landing/components/LandingNav.tsx src/components/PwaInstallButton.tsx src/app/providers.tsx --quiet`; linting completed but there are pre-existing `@typescript-eslint/no-explicit-any` errors in `src/components/PwaInstallButton.tsx` and `src/app/providers.tsx` unrelated to this change. 
- Changes were committed (`Adjust landing install CTA and mobile logo`). 
- No automated visual screenshot was taken in this environment (browser/screenshot tool not available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1416d340832cbd0c02f8b1e939be)