### PR TITLE
Fix mobile landing nav alignment and wire PWA install CTA to app shell event

### DIFF
--- a/src/app/landing/components/LandingNav.tsx
+++ b/src/app/landing/components/LandingNav.tsx
@@ -44,13 +44,16 @@ export default function LandingNav() {
             : "pt-8 pb-5"
         }`}
       >
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 flex items-center justify-between gap-3">
+        <div className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-4 sm:px-6">
           {/* Logo */}
           <Link
             href="/"
-            className="group order-2 ml-auto flex min-w-0 items-center justify-end gap-2 md:order-none md:ml-0"
+            className="group order-2 flex min-w-0 flex-1 items-center justify-center overflow-hidden md:order-none md:flex-none md:justify-start"
           >
-            <EnvitefyWordmark className="max-w-full text-[1.65rem] leading-none transition-transform duration-300 group-hover:scale-105 sm:text-[1.85rem] md:text-[2.2rem]" />
+            <EnvitefyWordmark
+              scaled={false}
+              className="max-w-full text-[1.5rem] leading-none transition-transform duration-300 group-hover:scale-105 sm:text-[1.75rem] md:text-[2.2rem]"
+            />
           </Link>
 
           {/* Desktop Nav */}
@@ -95,7 +98,7 @@ export default function LandingNav() {
 
           {/* Mobile Toggle */}
           <button
-            className="order-1 md:hidden p-2 text-gray-700"
+            className="order-1 shrink-0 p-2 text-gray-700 md:hidden"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             aria-label="Toggle menu"
           >

--- a/src/components/PwaInstallButton.tsx
+++ b/src/components/PwaInstallButton.tsx
@@ -295,7 +295,7 @@ const resolveInstallGuide = (win: Window): InstallGuide => {
   );
 };
 
-const BRIDGE_EVENT_NAME = "snapmydate:beforeinstallprompt";
+const BRIDGE_EVENT_NAME = "envitefy:beforeinstallprompt";
 const DEBUG_STORE_KEY = "__snapInstallDebugLog";
 const INSTALLED_FLAG_KEY = "snapmydate:pwa-installed";
 const MAX_DEBUG_ENTRIES = 50;


### PR DESCRIPTION
### Motivation

- Prevent the landing-page wordmark from being pushed too far right or clipped on small/mobile viewports by centering and constraining the logo instance used in the landing nav.  
- Ensure the install CTA can trigger the native Android/Chrome install prompt by using the same `beforeinstallprompt` bridge event the app shell emits instead of falling straight back to manual instructions.

### Description

- Adjusted `src/app/landing/components/LandingNav.tsx` to center/constrain the mobile wordmark and stop the hamburger button from shrinking into the logo area; disabled the oversized scaling for that nav instance by passing `scaled={false}` and tuned class names (`flex-1`, `justify-center`, `overflow-hidden`, and `shrink-0`).  
- Updated `src/components/PwaInstallButton.tsx` to listen for the same bridge event name emitted by the app shell by changing `BRIDGE_EVENT_NAME` from `"snapmydate:beforeinstallprompt"` to `"envitefy:beforeinstallprompt"` so the native `beforeinstallprompt` flow can be used when available.

### Testing

- Ran `npx eslint src/app/landing/components/LandingNav.tsx src/components/PwaInstallButton.tsx`; lint reported pre-existing TypeScript lint errors in `src/components/PwaInstallButton.tsx` that are unrelated to the event-name change, and no new issues were introduced by these edits. (lint: failed due to pre-existing issues)  
- Verified repository changes with `git status --short` and committed the change (commit created successfully). (git: success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf19fda80c832c98e0cbbf5151eb2b)