### PR TITLE
Add route-aware mobile theme-color support and runtime sync

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -5,7 +5,7 @@
   "scope": "/",
   "display": "standalone",
   "background_color": "#F8F5FF",
-  "theme_color": "#0b0b0f",
+  "theme_color": "#7F67D3",
   "icons": [
     { "src": "/icons/icon-48.png", "sizes": "48x48", "type": "image/png" },
     { "src": "/icons/icon-72.png", "sizes": "72x72", "type": "image/png" },

--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -57,6 +57,7 @@ import { cleanRsvpContactLabel } from "@/utils/rsvp";
 import { buildEventPath, buildEventSlugSegment } from "@/utils/event-url";
 import { BIRTHDAY_THEMES } from "@/components/birthdays/birthdayThemes";
 import { cache } from "react";
+import { resolveEventThemeColor } from "@/lib/theme-color";
 import { isGymMeetTemplateId } from "@/components/gym-meet-templates/registry";
 import {
   getEventAccessCookieName,
@@ -207,6 +208,17 @@ export async function generateMetadata(props: {
     alternates: {
       canonical: url,
     },
+  };
+}
+
+export async function generateViewport(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const awaitedParams = await props.params;
+  const row = await getCachedEventHistoryBySlugOrId(awaitedParams.id, null);
+
+  return {
+    themeColor: resolveEventThemeColor(row?.data || null),
   };
 }
 
@@ -1141,6 +1153,7 @@ export default async function EventPage({
     imageColors?.headerLight ||
     headerGradientCss ||
     (eventTheme.headerLight as string);
+  const eventPageThemeColor = resolveEventThemeColor(data);
 
   const themeStyleVars = {
     "--event-header-gradient-light": themedHeaderGradient,
@@ -1540,6 +1553,7 @@ export default async function EventPage({
           ? "pb-[calc(1em+env(safe-area-inset-bottom))]"
           : "pb-[calc(6rem+env(safe-area-inset-bottom))] md:pb-[calc(1em+env(safe-area-inset-bottom))]"
       }`}
+      data-theme-color={eventPageThemeColor}
       style={
         {
           // Keep page chrome in the white/purple family for scanned event views.

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -1,16 +1,25 @@
+import type { Metadata, Viewport } from "next";
 import Link from "next/link";
 import { Camera, ChevronLeft } from "lucide-react";
 import UploadDropCard from "./UploadDropCard";
+import { themeColorPalette } from "@/lib/theme-color";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Snap or upload invite · Envitefy",
   description:
     "Scan a flyer with your camera or upload an image to create your event.",
 };
 
+export const viewport: Viewport = {
+  themeColor: themeColorPalette.eventFallback,
+};
+
 export default function EventSnapLandingPage() {
   return (
-    <main className="min-h-screen bg-[#f5f6f7] px-4 py-10 sm:px-6 lg:px-10">
+    <main
+      className="min-h-screen bg-[#f5f6f7] px-4 py-10 sm:px-6 lg:px-10"
+      data-theme-color={themeColorPalette.eventFallback}
+    >
       <div className="mx-auto w-full max-w-5xl">
         <Link
           href="/"

--- a/src/app/football/page.tsx
+++ b/src/app/football/page.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import FootballLanding from "@/components/football-landing/FootballLanding";
+import { themeColorPalette } from "@/lib/theme-color";
 
 export const metadata: Metadata = {
   title: "Envitefy Football | Premium season pages for teams and families",
@@ -19,6 +20,10 @@ export const metadata: Metadata = {
     description:
       "Premium football season pages with editorial layouts, live updates, travel details, and mobile-first presentation.",
   },
+};
+
+export const viewport: Viewport = {
+  themeColor: themeColorPalette.football,
 };
 
 export default function FootballPage() {

--- a/src/app/gymnastics/page.tsx
+++ b/src/app/gymnastics/page.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import GymnasticsLanding from "@/components/gymnastics-landing/GymnasticsLanding";
+import { themeColorPalette } from "@/lib/theme-color";
 
 export const metadata: Metadata = {
   title: "Envitefy Gymnastics | Premium meet pages for families and coaches",
@@ -19,6 +20,10 @@ export const metadata: Metadata = {
     description:
       "Premium gymnastics meet pages with editorial layouts, live updates, hotel details, and mobile-first presentation.",
   },
+};
+
+export const viewport: Viewport = {
+  themeColor: themeColorPalette.gymnastics,
 };
 
 export default function GymnasticsPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Providers from "./providers";
 import AppShell from "./AppShell";
 import "./globals.css";
 import { resolveThemeCssVariables, ThemeKey, ThemeVariant } from "@/themes";
+import { themeColorPalette } from "@/lib/theme-color";
 import { Suspense } from "react";
 import type { CSSProperties } from "react";
 
@@ -135,7 +136,7 @@ export const metadata: Metadata = {
   },
   appleWebApp: {
     capable: true,
-    statusBarStyle: "black-translucent",
+    statusBarStyle: "default",
     title: "Envitefy",
   },
   openGraph: {
@@ -160,10 +161,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#F8F5FF" },
-    { media: "(prefers-color-scheme: dark)", color: "#0b0b0f" },
-  ],
+  themeColor: themeColorPalette.brand,
 };
 
 export default function RootLayout({
@@ -183,16 +181,11 @@ export default function RootLayout({
       lang="en"
       data-theme={`${themeKey}-${htmlVariant}`}
       data-theme-key={themeKey}
-      style={{ ...htmlStyle, backgroundColor: "#F8F5FF" }}
+      style={{ ...htmlStyle, backgroundColor: themeColorPalette.background }}
       suppressHydrationWarning
     >
       <head>
         <title>Envitefy | Create. Share. Enjoy.</title>
-        <meta
-          name="apple-mobile-web-app-status-bar-style"
-          content="black-translucent"
-        />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
         <Script
           id="ld-website"
           type="application/ld+json"

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -16,6 +16,7 @@ import GlobalEventCreate from "./GlobalEventCreate";
 import GlobalSmartSignup from "./GlobalSmartSignup";
 import PwaInstallButton from "@/components/PwaInstallButton";
 import PwaInstallToast from "@/components/PwaInstallToast";
+import ThemeColorSync from "@/components/ThemeColorSync";
 import { ThemeKey, ThemeVariant, resolveThemeCssVariables } from "@/themes";
 
 type ThemeContextValue = {
@@ -90,6 +91,7 @@ export default function Providers({
         <ThemeProvider>
           <RegisterServiceWorker />
           <PwaInstallToast />
+          <ThemeColorSync />
           <GymnasticsDemoDraftClaimListener />
           {children}
           <GlobalEventCreate />

--- a/src/components/ThemeColorSync.tsx
+++ b/src/components/ThemeColorSync.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import {
+  getPreferredThemeColor,
+  getThemeColorForPath,
+  HERO_THEME_COLOR_ATTRIBUTE,
+  setThemeColor,
+} from "@/lib/theme-color";
+
+export default function ThemeColorSync() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    setThemeColor(getThemeColorForPath(pathname));
+  }, [pathname]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    let frame = 0;
+    let lastApplied = "";
+
+    const applyPreferredColor = () => {
+      frame = 0;
+      const next = getPreferredThemeColor(pathname);
+      if (next && next !== lastApplied) {
+        setThemeColor(next);
+        lastApplied = next;
+      }
+    };
+
+    const scheduleApply = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(applyPreferredColor);
+    };
+
+    scheduleApply();
+
+    const observer = new MutationObserver(() => {
+      scheduleApply();
+    });
+
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: [HERO_THEME_COLOR_ATTRIBUTE],
+    });
+
+    window.addEventListener("scroll", scheduleApply, { passive: true });
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("scroll", scheduleApply);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/src/lib/theme-color.ts
+++ b/src/lib/theme-color.ts
@@ -1,0 +1,159 @@
+const BRAND_THEME_COLOR = "#7F67D3";
+const BRAND_BACKGROUND_COLOR = "#F8F5FF";
+const GYMNASTICS_THEME_COLOR = "#7C5CDB";
+const FOOTBALL_THEME_COLOR = "#1F5A45";
+const EVENT_THEME_COLOR_FALLBACK = BRAND_THEME_COLOR;
+
+export type ThemeColorSource = "route" | "hero" | "event" | "default";
+
+export type ThemeColorDefinition = {
+  color: string;
+  source: ThemeColorSource;
+};
+
+export const THEME_COLOR_META_NAME = "theme-color";
+export const THEME_COLOR_SELECTOR = 'meta[name="theme-color"]';
+export const HERO_THEME_COLOR_ATTRIBUTE = "data-theme-color";
+
+const EVENT_ROUTE_PATTERN = /^\/event(?:\/|$)/;
+
+function normalizeColor(value?: string | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^#[0-9a-f]{3}([0-9a-f]{3})?$/i.test(trimmed)) return trimmed;
+  if (/^rgb(a)?\(/i.test(trimmed)) return trimmed;
+  if (/^hsl(a)?\(/i.test(trimmed)) return trimmed;
+  return null;
+}
+
+export function getThemeColorForPath(pathname?: string | null): string {
+  const path = pathname || "/";
+
+  if (path === "/gymnastics" || path.startsWith("/event/gymnastics")) {
+    return GYMNASTICS_THEME_COLOR;
+  }
+
+  if (path === "/football" || path.startsWith("/event/football")) {
+    return FOOTBALL_THEME_COLOR;
+  }
+
+  if (EVENT_ROUTE_PATTERN.test(path)) {
+    return EVENT_THEME_COLOR_FALLBACK;
+  }
+
+  return BRAND_THEME_COLOR;
+}
+
+export function getThemeColorDefinitionForPath(
+  pathname?: string | null,
+): ThemeColorDefinition {
+  const color = getThemeColorForPath(pathname);
+  const source: ThemeColorSource = pathname
+    ? EVENT_ROUTE_PATTERN.test(pathname)
+      ? "event"
+      : pathname === "/gymnastics" || pathname.startsWith("/event/gymnastics")
+        ? "route"
+        : pathname === "/football" || pathname.startsWith("/event/football")
+          ? "route"
+          : "default"
+    : "default";
+
+  return { color, source };
+}
+
+export function resolveEventThemeColor(input?: unknown): string {
+  if (!input || typeof input !== "object") return EVENT_THEME_COLOR_FALLBACK;
+  const data = input as Record<string, unknown>;
+  const theme = typeof data.theme === "object" && data.theme ? (data.theme as Record<string, unknown>) : null;
+  const event = typeof data.event === "object" && data.event ? (data.event as Record<string, unknown>) : null;
+  const imageColors =
+    typeof data.imageColors === "object" && data.imageColors
+      ? (data.imageColors as Record<string, unknown>)
+      : null;
+  const flyerColors =
+    typeof data.flyerColors === "object" && data.flyerColors
+      ? (data.flyerColors as Record<string, unknown>)
+      : null;
+
+  const candidateColors = [
+    data.themeColor,
+    theme?.color,
+    theme?.accentColor,
+    data.accentColor,
+    data.color,
+    event?.themeColor,
+    event?.accentColor,
+    event?.color,
+    imageColors?.headerDark,
+    imageColors?.headerLight,
+    flyerColors?.themeColor,
+    flyerColors?.accentColor,
+    flyerColors?.dominant,
+  ];
+
+  for (const candidate of candidateColors) {
+    const normalized = normalizeColor(
+      typeof candidate === "string"
+        ? extractSolidColor(candidate)
+        : null,
+    );
+    if (normalized) return normalized;
+  }
+
+  return EVENT_THEME_COLOR_FALLBACK;
+}
+
+function extractSolidColor(value: string): string | null {
+  const direct = normalizeColor(value);
+  if (direct) return direct;
+
+  const hexMatch = value.match(/#[0-9a-f]{3,8}/i);
+  if (hexMatch) return hexMatch[0];
+
+  const rgbMatch = value.match(/rgba?\([^\)]+\)/i);
+  if (rgbMatch) return rgbMatch[0];
+
+  const hslMatch = value.match(/hsla?\([^\)]+\)/i);
+  if (hslMatch) return hslMatch[0];
+
+  return null;
+}
+
+export function setThemeColor(color: string) {
+  if (typeof document === "undefined") return;
+  const normalized = normalizeColor(extractSolidColor(color) || color);
+  if (!normalized) return;
+
+  let meta = document.querySelector<HTMLMetaElement>(THEME_COLOR_SELECTOR);
+  if (!meta) {
+    meta = document.createElement("meta");
+    meta.setAttribute("name", THEME_COLOR_META_NAME);
+    document.head.appendChild(meta);
+  }
+
+  if (meta.content !== normalized) {
+    meta.content = normalized;
+  }
+}
+
+export function getHeroThemeColor(): string | null {
+  if (typeof document === "undefined") return null;
+  const hero = document.querySelector<HTMLElement>(`[${HERO_THEME_COLOR_ATTRIBUTE}]`);
+  return normalizeColor(hero?.getAttribute(HERO_THEME_COLOR_ATTRIBUTE));
+}
+
+export function getPreferredThemeColor(pathname?: string | null): string {
+  return getHeroThemeColor() || getThemeColorForPath(pathname);
+}
+
+export const themeColorPalette = {
+  brand: BRAND_THEME_COLOR,
+  background: BRAND_BACKGROUND_COLOR,
+  gymnastics: GYMNASTICS_THEME_COLOR,
+  football: FOOTBALL_THEME_COLOR,
+  eventFallback: EVENT_THEME_COLOR_FALLBACK,
+} as const;
+
+// TODO: When server-side dominant-color extraction for event flyers becomes stable,
+// prefer a persisted event.branding.themeColor value before generic fallback colors.


### PR DESCRIPTION
### Motivation
- Make the browser chrome and installed PWA UI feel visually integrated with each page by providing a consistent `theme-color` across Android, Safari Home Screen, and webviews where supported.
- Provide per-route defaults (gymnastics, football, event) and a safe event-page fallback while keeping a clear upgrade path for server-side dominant-color extraction later.
- Keep the runtime update lightweight and hydration-safe so theme updates happen immediately on navigation without layout jank.

### Description
- Add a centralized helper `src/lib/theme-color.ts` that exposes `getThemeColorForPath()`, `resolveEventThemeColor()`, `setThemeColor()` and small constants/palette used across the app for route and event fallbacks.
- Implement a small client component `src/components/ThemeColorSync.tsx` that mounts globally and updates the `<meta name="theme-color">` on route change and when a page exposes a hero override via `data-theme-color`.
- Wire theme-color into App Router metadata/viewport and per-route viewports by updating `src/app/layout.tsx` (global `viewport.themeColor`) and adding `viewport.themeColor` or `data-theme-color` to `/gymnastics`, `/football`, `/event` and dynamic `/event/[id]` pages so Android and PWAs get route-aware values; event pages use existing persisted event color fields when present via `resolveEventThemeColor()`.
- Align the installed PWA manifest `public/manifest.webmanifest` to Envitefy brand values by setting `theme_color: "#7F67D3"` and preserve `background_color: "#F8F5FF"` so installed web apps use the same brand fallback.

### Testing
- Ran a focused lint sweep on modified files with `npx eslint src/lib/theme-color.ts src/components/ThemeColorSync.tsx src/app/gymnastics/page.tsx src/app/football/page.tsx src/app/event/page.tsx` and verified the changed files are syntactically valid for the applied edits.
- Verified presence and locations of metadata/manifest changes with `rg -n "theme-color|apple-mobile-web-app-capable|apple-mobile-web-app-status-bar-style|theme_color|background_color" src/app public/manifest.webmanifest` and confirmed updates are present.
- Attempted a full production build with `npm run build` in this environment but the build did not complete within the observed window, so full production build verification should be run in CI or locally to confirm end-to-end.
- No runtime regressions expected; follow-up manual checks on Android Chrome and iOS Safari (Home Screen) are recommended to validate platform visual behavior and any contrast adjustments for extreme event colors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1b2b2bc0832cb62a094f4eb71c50)