### PR TITLE
Prevent Studio create step reset when URL `step` param is missing

### DIFF
--- a/src/app/studio/StudioWorkspace.step-sync.source.test.mjs
+++ b/src/app/studio/StudioWorkspace.step-sync.source.test.mjs
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+function readSource(relPath) {
+  return fs.readFileSync(path.join(process.cwd(), relPath), "utf8");
+}
+
+test("studio workspace does not force type step when URL has no step param", () => {
+  const source = readSource("src/app/studio/StudioWorkspace.tsx");
+
+  assert.match(source, /const stepParam = searchParams\.get\("step"\);/);
+  assert.match(source, /const nextCreateStep = stepParam \? parseStudioCreateStep\(stepParam\) : null;/);
+  assert.match(source, /if \(nextView === "create" && safeCreateStep\) \{/);
+});

--- a/src/app/studio/StudioWorkspace.tsx
+++ b/src/app/studio/StudioWorkspace.tsx
@@ -511,12 +511,13 @@ export default function StudioWorkspace() {
 
   useEffect(() => {
     const nextView = parseStudioWorkspaceView(searchParams.get("view"));
-    const nextCreateStep = parseStudioCreateStep(searchParams.get("step"));
+    const stepParam = searchParams.get("step");
+    const nextCreateStep = stepParam ? parseStudioCreateStep(stepParam) : null;
     const safeCreateStep =
-      nextView === "create" && nextCreateStep === "editor" && !formValid ? "details" : nextCreateStep;
+      nextCreateStep === "editor" && !formValid ? "details" : nextCreateStep;
 
     setView((current) => (current === nextView ? current : nextView));
-    if (nextView === "create") {
+    if (nextView === "create" && safeCreateStep) {
       setCreateStep((current) => (current === safeCreateStep ? current : safeCreateStep));
     }
   }, [formValid, searchParams]);


### PR DESCRIPTION
### Motivation
- Users on the Studio details form were intermittently being pushed back to the category/type step while filling fields because the workspace URL/state sync treated a missing `step` query parameter as a default and reapplied it.

### Description
- Change the URL sync effect in `src/app/studio/StudioWorkspace.tsx` to only update `createStep` when a real `step` query parameter exists (`const stepParam = searchParams.get("step")` and `nextCreateStep = stepParam ? parseStudioCreateStep(stepParam) : null`).
- Preserve the safety behavior that coerces an invalid `editor` state back to `details` when required fields are missing.
- Add a source-level regression guard `src/app/studio/StudioWorkspace.step-sync.source.test.mjs` to lock the intended behavior and prevent regressions.

### Testing
- Ran `node --test src/app/studio/StudioWorkspace.step-sync.source.test.mjs src/app/studio/StudioWorkspace.current-project-flow.source.test.mjs` and both tests passed.
- Ran `npm run lint -- src/app/studio/StudioWorkspace.tsx src/app/studio/StudioWorkspace.step-sync.source.test.mjs`, which surfaced many pre-existing repository-wide Biome diagnostics unrelated to this change (lint reported failures from other files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2b7223a9c832ca48bb0dd3718d67e)