### PR TITLE
Fix mobile Live Card Showcase taps intercepted by hidden nav menu

### DIFF
--- a/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
+++ b/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
@@ -16,6 +16,7 @@ test("HeroTopNav keeps desktop auth actions while using inline login inside the 
   assert.match(source, /if \(!mobileMenuOpen\) {\s*setMobileLoginExpanded\(false\);/s);
   assert.match(source, /onClick=\{\(\) => setMobileLoginExpanded\(\(value\) => !value\)\}/);
   assert.match(source, /id="hero-top-nav-mobile-login"/);
+  assert.match(source, /mobileMenuOpen \? "pointer-events-auto" : "pointer-events-none"/);
   assert.match(source, /<LoginForm\s+variant="inline"/);
   assert.match(source, /inlineTone=\{isDarkGlass \? "dark" : "light"\}/);
   assert.match(source, /showGoogleAuth=\{false\}/);

--- a/src/components/navigation/HeroTopNav.tsx
+++ b/src/components/navigation/HeroTopNav.tsx
@@ -279,7 +279,8 @@ export default function HeroTopNav({
 
           <div
             className={cx(
-              "nav-chrome-menu-card pointer-events-auto relative ml-auto mt-2 w-full max-w-[20rem] p-3",
+              "nav-chrome-menu-card relative ml-auto mt-2 w-full max-w-[20rem] p-3",
+              mobileMenuOpen ? "pointer-events-auto" : "pointer-events-none",
               isDarkGlass
                 ? "theme-glass-menu rounded-[1.75rem] border border-white/12 shadow-[0_24px_54px_rgba(0,0,0,0.26)]"
                 : "rounded-[1.75rem]",


### PR DESCRIPTION
### Motivation
- Mobile users tapping the “Live Card Showcase” area were sometimes routed to `#use-cases` or a signup modal because an invisible mobile nav layer could intercept touches. 
- The mobile menu dropdown used opacity/translate transitions while remaining pointer-active, creating an invisible hit target over downstream page content. 

### Description
- Gate pointer events on the mobile menu card so it only receives pointers when the menu is open by adding `mobileMenuOpen ? "pointer-events-auto" : "pointer-events-none"` to the `nav-chrome-menu-card` container in `src/components/navigation/HeroTopNav.tsx`. 
- Remove the unconditional `pointer-events-auto` to prevent the hidden mobile menu from intercepting taps over the Live Card Showcase and other sections. 
- Add a regression source-test assertion in `src/components/navigation/HeroTopNav.mobile-login.source.test.mjs` to ensure the pointer-events guard remains present. 

### Testing
- Ran `node --test src/components/navigation/HeroTopNav.mobile-login.source.test.mjs` and the test passed. 
- Ran `npx biome lint src/components/navigation/HeroTopNav.tsx src/components/navigation/HeroTopNav.mobile-login.source.test.mjs` with no lint errors. 
- Attempted to reproduce click behavior with Playwright, but `npx playwright install chromium` failed in this environment due to a CDN 403 so full runtime click-mapping could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e400ff82f0832c81b2c769451c98be)