### PR TITLE
Harden mobile nav hit area and restore native swipe for Live Card Showcase

### DIFF
--- a/src/app/landing/page.test.mjs
+++ b/src/app/landing/page.test.mjs
@@ -53,7 +53,11 @@ test("landing page renders the new dedicated landing experience component", () =
   assert.match(landingShowcase, /const handleShowcasePointerMove = \(event: React\.PointerEvent<HTMLDivElement>\) => \{/);
   assert.match(landingShowcase, /const deltaX = event\.clientX - swipeState\.startX;/);
   assert.match(landingShowcase, /const deltaY = event\.clientY - swipeState\.startY;/);
-  assert.match(landingShowcase, /scrollToShowcaseIndex\(swipeState\.index \+ \(deltaX < 0 \? 1 : -1\)\);/);
+  assert.match(landingShowcase, /suppressShowcaseClick\(\);/);
+  assert.doesNotMatch(
+    landingShowcase,
+    /scrollToShowcaseIndex\(swipeState\.index \+ \(deltaX < 0 \? 1 : -1\)\);/,
+  );
   assert.match(landingShowcase, /onPointerDownCapture=\{\(event\) => handleShowcasePointerDown\(index, event\)\}/);
   assert.match(landingShowcase, /onPointerMoveCapture=\{handleShowcasePointerMove\}/);
   assert.match(landingShowcase, /onPointerUpCapture=\{clearShowcaseSwipeState\}/);
@@ -72,7 +76,7 @@ test("landing page renders the new dedicated landing experience component", () =
   );
   assert.match(
     landingShowcase,
-    /w-\[min\(272px,calc\(100vw-5\.5rem\)\)\] shrink-0 snap-center cursor-pointer sm:w-\[min\(300px,calc\(100vw-4rem\)\)\]/,
+    /w-\[min\(272px,calc\(100vw-5\.5rem\)\)\] shrink-0 snap-center cursor-pointer touch-pan-y sm:w-\[min\(300px,calc\(100vw-4rem\)\)\]/,
   );
   assert.match(landingShowcase, /import \{ resolveNativeShareData \} from "@\/utils\/native-share";/);
   assert.match(landingShowcase, /const nativeShareData = resolveNativeShareData\(sharePayload\);/);

--- a/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
+++ b/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
@@ -47,12 +47,16 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   );
   assert.match(source, /const deltaX = event\.clientX - swipeState\.startX;/);
   assert.match(source, /const deltaY = event\.clientY - swipeState\.startY;/);
-  assert.match(source, /scrollToShowcaseIndex\(swipeState\.index \+ \(deltaX < 0 \? 1 : -1\)\);/);
+  assert.match(source, /suppressShowcaseClick\(\);/);
+  assert.doesNotMatch(source, /scrollToShowcaseIndex\(swipeState\.index \+ \(deltaX < 0 \? 1 : -1\)\);/);
   assert.match(
     source,
     /target\.closest\("\[data-live-card-trigger\], \[data-live-card-panel\], button, a"\)/,
   );
-  assert.match(source, /if \(index !== activeIndex\) \{\s*scrollToShowcaseIndex\(index\);/);
+  assert.match(
+    source,
+    /if \(index !== activeIndex\) \{\s*event\?\.preventDefault\(\);\s*event\?\.stopPropagation\(\);\s*scrollToShowcaseIndex\(index\);\s*return;\s*\}/,
+  );
   assert.match(
     source,
     /setShowcaseOverlayIndex\(\(current\) => \(current === index \? null : index\)\);/,
@@ -75,7 +79,7 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   assert.doesNotMatch(source, /await navigator\.share\(candidate\);/);
   assert.match(
     source,
-    /className="w-\[min\(300px,calc\(100vw-4rem\)\)\] shrink-0 snap-center cursor-pointer"/,
+    /className="w-\[min\(300px,calc\(100vw-4rem\)\)\] shrink-0 snap-center cursor-pointer touch-pan-y"/,
   );
   assert.match(source, /activeIndex === index\s*\?\s*"scale-100 opacity-100 blur-0"/);
   assert.match(source, /:\s*"scale-\[0\.85\] opacity-40 blur-\[2px\]"/);
@@ -95,6 +99,6 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   assert.match(source, /md:inline-flex/);
   assert.match(
     source,
-    /<StudioMarketingLiveCard\s+preview=\{item\.preview\}\s+compactChrome\s+showcaseMode\s+imageLoading="lazy"\s+showcaseOverlay=/,
+    /<StudioMarketingLiveCard\s+preview=\{item\.preview\}\s+compactChrome\s+showcaseMode\s+interactive=\{activeIndex === index\}\s+imageLoading="lazy"\s+showcaseOverlay=/,
   );
 });

--- a/src/app/studio/StudioMarketingPage.tsx
+++ b/src/app/studio/StudioMarketingPage.tsx
@@ -1193,7 +1193,6 @@ export default function StudioMarketingPage() {
 
     swipeState.didSwipe = true;
     suppressShowcaseClick();
-    scrollToShowcaseIndex(swipeState.index + (deltaX < 0 ? 1 : -1));
   };
 
   const clearShowcaseSwipeState = (event?: React.PointerEvent<HTMLDivElement>) => {
@@ -1705,7 +1704,7 @@ export default function StudioMarketingPage() {
                   onPointerCancelCapture={clearShowcaseSwipeState}
                   data-showcase-card
                   data-showcase-card-index={index}
-                  className="w-[min(300px,calc(100vw-4rem))] shrink-0 snap-center cursor-pointer"
+                  className="w-[min(300px,calc(100vw-4rem))] shrink-0 snap-center cursor-pointer touch-pan-y"
                 >
                       <div
                         className={cx(

--- a/src/components/landing/LandingLiveCardShowcase.tsx
+++ b/src/components/landing/LandingLiveCardShowcase.tsx
@@ -442,7 +442,6 @@ export default function LandingLiveCardShowcase() {
 
     swipeState.didSwipe = true;
     suppressShowcaseClick();
-    scrollToShowcaseIndex(swipeState.index + (deltaX < 0 ? 1 : -1));
   };
 
   const clearShowcaseSwipeState = (event?: React.PointerEvent<HTMLDivElement>) => {
@@ -532,7 +531,7 @@ export default function LandingLiveCardShowcase() {
                   onPointerCancelCapture={clearShowcaseSwipeState}
                   data-showcase-card
                   data-showcase-card-index={index}
-                  className="w-[min(272px,calc(100vw-5.5rem))] shrink-0 snap-center cursor-pointer sm:w-[min(300px,calc(100vw-4rem))]"
+                  className="w-[min(272px,calc(100vw-5.5rem))] shrink-0 snap-center cursor-pointer touch-pan-y sm:w-[min(300px,calc(100vw-4rem))]"
                 >
                   <div
                     className={cx(

--- a/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
+++ b/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
@@ -16,6 +16,8 @@ test("HeroTopNav keeps desktop auth actions while using inline login inside the 
   assert.match(source, /if \(!mobileMenuOpen\) {\s*setMobileLoginExpanded\(false\);/s);
   assert.match(source, /onClick=\{\(\) => setMobileLoginExpanded\(\(value\) => !value\)\}/);
   assert.match(source, /id="hero-top-nav-mobile-login"/);
+  assert.match(source, /mobileMenuOpen \? "pointer-events-auto" : "pointer-events-none"/);
+  assert.match(source, /mobileMenuOpen\s*\?\s*"visible translate-y-0 opacity-100"\s*:\s*"invisible -translate-y-2 opacity-0"/);
   assert.match(source, /<LoginForm\s+variant="inline"/);
   assert.match(source, /inlineTone=\{isDarkGlass \? "dark" : "light"\}/);
   assert.match(source, /showGoogleAuth=\{false\}/);

--- a/src/components/navigation/HeroTopNav.tsx
+++ b/src/components/navigation/HeroTopNav.tsx
@@ -248,10 +248,10 @@ export default function HeroTopNav({
 
         <div
           id="hero-top-nav-mobile"
-          className={`pointer-events-none absolute right-0 top-[calc(100%-0.55rem)] z-10 w-full pt-0 transition-[opacity,transform] duration-300 lg:hidden ${
+          className={`pointer-events-none absolute right-0 top-[calc(100%-0.55rem)] z-10 w-full pt-0 transition-[opacity,transform,visibility] duration-300 lg:hidden ${
             mobileMenuOpen
-              ? "translate-y-0 opacity-100"
-              : "-translate-y-2 opacity-0"
+              ? "visible translate-y-0 opacity-100"
+              : "invisible -translate-y-2 opacity-0"
           }`}
         >
           <div
@@ -279,7 +279,8 @@ export default function HeroTopNav({
 
           <div
             className={cx(
-              "nav-chrome-menu-card pointer-events-auto relative ml-auto mt-2 w-full max-w-[20rem] p-3",
+              "nav-chrome-menu-card relative ml-auto mt-2 w-full max-w-[20rem] p-3",
+              mobileMenuOpen ? "pointer-events-auto" : "pointer-events-none",
               isDarkGlass
                 ? "theme-glass-menu rounded-[1.75rem] border border-white/12 shadow-[0_24px_54px_rgba(0,0,0,0.26)]"
                 : "rounded-[1.75rem]",


### PR DESCRIPTION
### Motivation

- Mobile taps on the “Live Card Showcase” were being misrouted because a visually-hidden mobile nav dropdown could still intercept pointer input.  
- Native horizontal swipe through showcase cards was being overridden by a programmatic swipe-advance on pointer move, preventing natural touch scrolling.

### Description

- Make the mobile nav container explicitly `invisible` when closed and move the `pointer-events` gating to the menu card so the hidden menu cannot create an invisible hit target (`src/components/navigation/HeroTopNav.tsx`).
- Stop advancing the carousel on pointer-move in both showcase implementations and keep swipe handling limited to detecting/swallowing accidental click-after-drag by calling `suppressShowcaseClick()` only (`src/components/landing/LandingLiveCardShowcase.tsx` and `src/app/studio/StudioMarketingPage.tsx`).
- Add `touch-pan-y` on each showcase card element so touch gestures cooperate with native browser panning and the horizontal scroll remains native (`LandingLiveCardShowcase` and `StudioMarketingPage`).
- Update source-shape/regression tests to reflect the new native-swipe behavior and the mobile menu visibility/pointer-events expectations (`src/app/landing/page.test.mjs`, `src/app/studio/StudioMarketingPage.showcase.source.test.mjs`, `src/components/navigation/HeroTopNav.mobile-login.source.test.mjs`).

### Testing

- Ran the focused source-shape tests with `node --test src/app/studio/StudioMarketingPage.showcase.source.test.mjs src/app/landing/page.test.mjs src/components/navigation/HeroTopNav.mobile-login.source.test.mjs` and all tests passed.  
- Ran linting with `npx biome lint <files>` for the touched files and there were no reported fixes or lint failures.  
- All automated test assertions added/updated to guard the pointer-events/visibility change and the native-swipe behavior are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e400ff82f0832c81b2c769451c98be)