### PR TITLE
Fix live-card showcase mobile swipe and tap behavior

### DIFF
--- a/src/app/landing/page.test.mjs
+++ b/src/app/landing/page.test.mjs
@@ -49,7 +49,10 @@ test("landing page renders the new dedicated landing experience component", () =
   assert.match(landingShowcase, /const showcaseSwipeStateRef = useRef<\{/);
   assert.match(landingShowcase, /const suppressShowcaseClickRef = useRef\(false\);/);
   assert.match(landingShowcase, /const handleShowcasePointerDown = \(\s*index: number,\s*event: React\.PointerEvent<HTMLDivElement>,/);
-  assert.match(landingShowcase, /if \(!event\.isPrimary \|\| event\.pointerType === "mouse"\) return;/);
+  assert.match(
+    landingShowcase,
+    /if \(!event\.isPrimary \|\| event\.pointerType === "mouse" \|\| event\.pointerType === "touch"\) return;/,
+  );
   assert.match(landingShowcase, /const handleShowcasePointerMove = \(event: React\.PointerEvent<HTMLDivElement>\) => \{/);
   assert.match(landingShowcase, /const deltaX = event\.clientX - swipeState\.startX;/);
   assert.match(landingShowcase, /const deltaY = event\.clientY - swipeState\.startY;/);
@@ -68,7 +71,7 @@ test("landing page renders the new dedicated landing experience component", () =
   assert.match(landingShowcase, /event\?\.stopPropagation\(\);/);
   assert.match(
     landingShowcase,
-    /gap-4 overflow-x-auto scroll-smooth px-\[max\(1\.25rem,calc\(50vw-136px\)\)\] py-8 snap-x snap-mandatory sm:gap-6 sm:px-\[max\(2rem,calc\(50vw-150px\)\)\]/,
+    /touch-pan-x items-start gap-4 overflow-x-auto overscroll-x-contain scroll-smooth px-\[max\(1\.25rem,calc\(50vw-136px\)\)\] py-8 snap-x snap-mandatory sm:gap-6 sm:px-\[max\(2rem,calc\(50vw-150px\)\)\]/,
   );
   assert.match(
     landingShowcase,

--- a/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
+++ b/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
@@ -40,7 +40,10 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
     source,
     /const handleShowcasePointerDown = \(\s*index: number,\s*event: React\.PointerEvent<HTMLDivElement>,/,
   );
-  assert.match(source, /if \(!event\.isPrimary \|\| event\.pointerType === "mouse"\) return;/);
+  assert.match(
+    source,
+    /if \(!event\.isPrimary \|\| event\.pointerType === "mouse" \|\| event\.pointerType === "touch"\) return;/,
+  );
   assert.match(
     source,
     /const handleShowcasePointerMove = \(event: React\.PointerEvent<HTMLDivElement>\) => \{/,
@@ -52,7 +55,10 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
     source,
     /target\.closest\("\[data-live-card-trigger\], \[data-live-card-panel\], button, a"\)/,
   );
-  assert.match(source, /if \(index !== activeIndex\) \{\s*scrollToShowcaseIndex\(index\);/);
+  assert.match(
+    source,
+    /if \(index !== activeIndex\) \{\s*event\?\.preventDefault\(\);\s*event\?\.stopPropagation\(\);\s*scrollToShowcaseIndex\(index\);\s*return;\s*\}/,
+  );
   assert.match(
     source,
     /setShowcaseOverlayIndex\(\(current\) => \(current === index \? null : index\)\);/,
@@ -65,7 +71,7 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   assert.match(source, /onPointerCancelCapture=\{clearShowcaseSwipeState\}/);
   assert.match(
     source,
-    /className="no-scrollbar flex items-start gap-6 overflow-x-auto scroll-smooth px-\[max\(2rem,calc\(50vw-150px\)\)\] py-8 snap-x snap-mandatory"/,
+    /className="no-scrollbar flex touch-pan-x items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-\[max\(2rem,calc\(50vw-150px\)\)\] py-8 snap-x snap-mandatory"/,
   );
   assert.match(source, /onClick=\{\(event\) => handleShowcaseCardClick\(index, event\)\}/);
   assert.match(source, /import \{ resolveNativeShareData \} from "@\/utils\/native-share";/);
@@ -95,6 +101,6 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   assert.match(source, /md:inline-flex/);
   assert.match(
     source,
-    /<StudioMarketingLiveCard\s+preview=\{item\.preview\}\s+compactChrome\s+showcaseMode\s+imageLoading="lazy"\s+showcaseOverlay=/,
+    /<StudioMarketingLiveCard\s+preview=\{item\.preview\}\s+compactChrome\s+showcaseMode\s+interactive=\{activeIndex === index\}\s+imageLoading="lazy"\s+showcaseOverlay=/,
   );
 });

--- a/src/app/studio/StudioMarketingPage.tsx
+++ b/src/app/studio/StudioMarketingPage.tsx
@@ -1169,7 +1169,7 @@ export default function StudioMarketingPage() {
     index: number,
     event: React.PointerEvent<HTMLDivElement>,
   ) => {
-    if (!event.isPrimary || event.pointerType === "mouse") return;
+    if (!event.isPrimary || event.pointerType === "mouse" || event.pointerType === "touch") return;
     showcaseSwipeStateRef.current = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -1180,6 +1180,9 @@ export default function StudioMarketingPage() {
   };
 
   const handleShowcasePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "touch") {
+      return;
+    }
     const swipeState = showcaseSwipeStateRef.current;
     if (!swipeState || swipeState.pointerId !== event.pointerId || swipeState.didSwipe) {
       return;
@@ -1692,7 +1695,8 @@ export default function StudioMarketingPage() {
 
                 <div
                   ref={showcaseScrollRef}
-                  className="no-scrollbar flex items-start gap-6 overflow-x-auto scroll-smooth px-[max(2rem,calc(50vw-150px))] py-8 snap-x snap-mandatory"
+                  className="no-scrollbar flex touch-pan-x items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-[max(2rem,calc(50vw-150px))] py-8 snap-x snap-mandatory"
+                  style={{ WebkitOverflowScrolling: "touch" }}
                 >
               {showcaseCards.map((item, index) => (
                 <div

--- a/src/components/landing/LandingLiveCardShowcase.tsx
+++ b/src/components/landing/LandingLiveCardShowcase.tsx
@@ -418,7 +418,7 @@ export default function LandingLiveCardShowcase() {
     index: number,
     event: React.PointerEvent<HTMLDivElement>,
   ) => {
-    if (!event.isPrimary || event.pointerType === "mouse") return;
+    if (!event.isPrimary || event.pointerType === "mouse" || event.pointerType === "touch") return;
     showcaseSwipeStateRef.current = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -429,6 +429,9 @@ export default function LandingLiveCardShowcase() {
   };
 
   const handleShowcasePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "touch") {
+      return;
+    }
     const swipeState = showcaseSwipeStateRef.current;
     if (!swipeState || swipeState.pointerId !== event.pointerId || swipeState.didSwipe) {
       return;
@@ -519,7 +522,8 @@ export default function LandingLiveCardShowcase() {
 
             <div
               ref={showcaseScrollRef}
-              className="no-scrollbar flex items-start gap-4 overflow-x-auto scroll-smooth px-[max(1.25rem,calc(50vw-136px))] py-8 snap-x snap-mandatory sm:gap-6 sm:px-[max(2rem,calc(50vw-150px))]"
+              className="no-scrollbar flex touch-pan-x items-start gap-4 overflow-x-auto overscroll-x-contain scroll-smooth px-[max(1.25rem,calc(50vw-136px))] py-8 snap-x snap-mandatory sm:gap-6 sm:px-[max(2rem,calc(50vw-150px))]"
+              style={{ WebkitOverflowScrolling: "touch" }}
             >
               {showcaseCards.map((item, index) => (
                 <div


### PR DESCRIPTION
### Motivation

- Mobile users reported that tapping on live cards was unreliable and native horizontal swipes did not work on phones because the showcase was intercepting touch pointer events. 
- The intent is to let mobile browsers handle native horizontal scrolling while preserving existing non-touch pointer swipe behavior and click suppression for mouse/pen input.

### Description

- Stop intercepting touch pointers in the showcase swipe handlers by returning early when `event.pointerType === "touch"` in `handleShowcasePointerDown` and `handleShowcasePointerMove` so touch devices use native scrolling. 
- Enable mobile-friendly horizontal scrolling on the showcase rails by adding `touch-pan-x`, `overscroll-x-contain`, and an inline `WebkitOverflowScrolling: "touch"` style to the scroll container. 
- Update source-shape regression tests to expect the new touch-pointer guard and the updated carousel class string. 
- Changes made in `src/components/landing/LandingLiveCardShowcase.tsx`, `src/app/studio/StudioMarketingPage.tsx`, and the corresponding tests `src/app/landing/page.test.mjs` and `src/app/studio/StudioMarketingPage.showcase.source.test.mjs`.

### Testing

- Ran the source-shape regression tests with `node --test src/app/studio/StudioMarketingPage.showcase.source.test.mjs src/app/landing/page.test.mjs` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e407334908832c8567f7b429d0a995)