### PR TITLE
Fix mobile vertical scroll while touching live card showcase

### DIFF
--- a/src/app/landing/page.test.mjs
+++ b/src/app/landing/page.test.mjs
@@ -71,7 +71,7 @@ test("landing page renders the new dedicated landing experience component", () =
   assert.match(landingShowcase, /event\?\.stopPropagation\(\);/);
   assert.match(
     landingShowcase,
-    /touch-pan-x items-start gap-4 overflow-x-auto overscroll-x-contain scroll-smooth px-\[max\(1\.25rem,calc\(50vw-136px\)\)\] py-8 snap-x snap-mandatory sm:gap-6 sm:px-\[max\(2rem,calc\(50vw-150px\)\)\]/,
+    /touch-auto items-start gap-4 overflow-x-auto overscroll-x-contain scroll-smooth px-\[max\(1\.25rem,calc\(50vw-136px\)\)\] py-8 snap-x snap-mandatory sm:gap-6 sm:px-\[max\(2rem,calc\(50vw-150px\)\)\]/,
   );
   assert.match(
     landingShowcase,

--- a/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
+++ b/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
@@ -71,7 +71,7 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   assert.match(source, /onPointerCancelCapture=\{clearShowcaseSwipeState\}/);
   assert.match(
     source,
-    /className="no-scrollbar flex touch-pan-x items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-\[max\(2rem,calc\(50vw-150px\)\)\] py-8 snap-x snap-mandatory"/,
+    /className="no-scrollbar flex touch-auto items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-\[max\(2rem,calc\(50vw-150px\)\)\] py-8 snap-x snap-mandatory"/,
   );
   assert.match(source, /onClick=\{\(event\) => handleShowcaseCardClick\(index, event\)\}/);
   assert.match(source, /import \{ resolveNativeShareData \} from "@\/utils\/native-share";/);

--- a/src/app/studio/StudioMarketingPage.tsx
+++ b/src/app/studio/StudioMarketingPage.tsx
@@ -1695,7 +1695,7 @@ export default function StudioMarketingPage() {
 
                 <div
                   ref={showcaseScrollRef}
-                  className="no-scrollbar flex touch-pan-x items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-[max(2rem,calc(50vw-150px))] py-8 snap-x snap-mandatory"
+                  className="no-scrollbar flex touch-auto items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-[max(2rem,calc(50vw-150px))] py-8 snap-x snap-mandatory"
                   style={{ WebkitOverflowScrolling: "touch" }}
                 >
               {showcaseCards.map((item, index) => (

--- a/src/components/landing/LandingLiveCardShowcase.tsx
+++ b/src/components/landing/LandingLiveCardShowcase.tsx
@@ -522,7 +522,7 @@ export default function LandingLiveCardShowcase() {
 
             <div
               ref={showcaseScrollRef}
-              className="no-scrollbar flex touch-pan-x items-start gap-4 overflow-x-auto overscroll-x-contain scroll-smooth px-[max(1.25rem,calc(50vw-136px))] py-8 snap-x snap-mandatory sm:gap-6 sm:px-[max(2rem,calc(50vw-150px))]"
+              className="no-scrollbar flex touch-auto items-start gap-4 overflow-x-auto overscroll-x-contain scroll-smooth px-[max(1.25rem,calc(50vw-136px))] py-8 snap-x snap-mandatory sm:gap-6 sm:px-[max(2rem,calc(50vw-150px))]"
               style={{ WebkitOverflowScrolling: "touch" }}
             >
               {showcaseCards.map((item, index) => (


### PR DESCRIPTION
### Motivation
- Vertical swipes that start on the live-card showcase were being blocked by the carousel's touch handling, preventing normal page scrolling on mobile, so the touch handoff needs to allow up/down scrolling without breaking the carousel.

### Description
- Switched the showcase container class from `touch-pan-x` to `touch-auto` in `src/components/landing/LandingLiveCardShowcase.tsx` and `src/app/studio/StudioMarketingPage.tsx`, and updated the source-shape tests that assert the class strings in `src/app/landing/page.test.mjs` and `src/app/studio/StudioMarketingPage.showcase.source.test.mjs`.

### Testing
- Ran `node --test src/app/landing/page.test.mjs src/app/studio/StudioMarketingPage.showcase.source.test.mjs` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40ee46774832cb3cfc1009bf119e2)