### PR TITLE
Refine live-card action rail and add invited flyer lightbox hint

### DIFF
--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -1457,6 +1457,15 @@ export default async function EventPage({
           style={headerUserStyle}
         >
           {headerImageUrl && <div style={headerOverlayStyle} />}
+          {isOcrEvent && headerImageUrl ? (
+            <ThumbnailModal
+              src={headerImageUrl}
+              alt={`${title} invitation`}
+              showPreviewImage={false}
+              hintLabel="Open full image"
+              className="absolute inset-0 z-30 rounded-2xl bg-transparent"
+            />
+          ) : null}
           {/* Profile image should anchor to the header section bounds (not inner wrapper) */}
           {profileImageUrl && (
             <div

--- a/src/components/ThumbnailModal.tsx
+++ b/src/components/ThumbnailModal.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { Maximize2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useSidebar } from "@/app/sidebar-context";
 
@@ -6,10 +7,14 @@ export default function ThumbnailModal({
   src,
   alt,
   className,
+  showPreviewImage = true,
+  hintLabel = "Tap to expand",
 }: {
   src: string;
   alt?: string;
   className?: string;
+  showPreviewImage?: boolean;
+  hintLabel?: string;
 }) {
   const [open, setOpen] = useState(false);
   const { setIsCollapsed } = useSidebar();
@@ -27,20 +32,25 @@ export default function ThumbnailModal({
         type="button"
         onClick={() => setOpen(true)}
         className={
-          className ||
-          "absolute bottom-2 right-2 rounded border border-border bg-background/70 hover:bg-background shadow"
+          className
+            ? `relative ${className}`
+            : "relative absolute bottom-2 right-2 rounded border border-border bg-background/70 hover:bg-background shadow"
         }
         aria-label="Open flyer preview"
       >
-        <img
-          src={src}
-          alt={alt || "Flyer thumbnail"}
-          className={`object-cover rounded ${
-            className?.includes("max-w")
-              ? "h-auto w-full"
-              : "h-38 w-auto"
-          }`}
-        />
+        {showPreviewImage ? (
+          <img
+            src={src}
+            alt={alt || "Flyer thumbnail"}
+            className={`object-cover rounded ${
+              className?.includes("max-w") ? "h-auto w-full" : "h-38 w-auto"
+            }`}
+          />
+        ) : null}
+        <span className="pointer-events-none absolute bottom-2 right-2 inline-flex items-center gap-1 rounded-full border border-white/35 bg-black/55 px-2 py-1 text-[10px] font-semibold tracking-wide text-white shadow-lg backdrop-blur">
+          <Maximize2 className="h-3 w-3" />
+          {hintLabel}
+        </span>
       </button>
 
       {open && (

--- a/src/components/studio/StudioLiveCardActionSurface.tsx
+++ b/src/components/studio/StudioLiveCardActionSurface.tsx
@@ -442,11 +442,11 @@ export default function StudioLiveCardActionSurface(props: StudioLiveCardActionS
   );
 
   const isActionRailClosed = props.activeTab === "none";
-  const shouldHideClosedRailLabels = isActionRailClosed && props.showcaseMode;
+  const shouldHideClosedRailLabels = props.showcaseMode;
   const useExpandedActionButtons = !props.showcaseMode;
   const actionRailClassName = isActionRailClosed
-    ? `flex min-w-0 items-stretch justify-between gap-0 ${
-        props.showcaseMode ? "w-[calc(100%+1.25rem)] -ml-[0.625rem] px-0" : "w-full px-1"
+    ? `grid min-w-0 grid-flow-col auto-cols-fr items-stretch ${
+        props.showcaseMode ? "w-full gap-2 px-2" : "w-full gap-3 px-1"
       }`
     : "grid w-full min-w-0 grid-flow-col auto-cols-fr items-stretch gap-1 md:gap-3";
 
@@ -736,13 +736,13 @@ export default function StudioLiveCardActionSurface(props: StudioLiveCardActionS
                     disabled={isPending}
                     aria-pressed={button.key === "share" ? undefined : isPressed}
                     data-live-card-trigger
-                    className={`group flex min-w-0 flex-col items-center justify-start gap-0.5 py-1 transition-transform duration-150 active:scale-[0.97] md:gap-2 ${
+                    className={`group flex min-w-0 flex-col items-center justify-start gap-1 py-1 transition-transform duration-150 active:scale-[0.97] md:gap-2 ${
                       isActionRailClosed ? "w-auto px-0" : "h-full w-full px-0.5"
                     } ${props.isDesignMode ? "cursor-move" : ""}`}
                   >
                     <div
                       className={`rounded-full border backdrop-blur-md transition-all duration-200 ${
-                        useExpandedActionButtons ? "p-2.5 md:p-3.5" : "p-2 md:p-3"
+                        useExpandedActionButtons ? "p-3 md:p-4" : "p-2.5 md:p-3"
                       } ${
                         posterFirstHeroCard
                           ? isPressed
@@ -754,7 +754,7 @@ export default function StudioLiveCardActionSurface(props: StudioLiveCardActionS
                       } ${props.isDesignMode ? "ring-2 ring-[#c9b49a]" : ""}`}
                     >
                       <Icon
-                        className={`${useExpandedActionButtons ? "h-5 w-5 md:h-6 md:w-6" : "h-4 w-4 md:h-5 md:w-5"} ${
+                        className={`${useExpandedActionButtons ? "h-6 w-6 md:h-7 md:w-7" : "h-5 w-5 md:h-6 md:w-6"} ${
                           isPending
                             ? "animate-spin text-white"
                             : button.key === "share" && shareState === "success"
@@ -766,12 +766,12 @@ export default function StudioLiveCardActionSurface(props: StudioLiveCardActionS
                       />
                     </div>
                     <span
-                      className={`max-w-full truncate text-center text-[7px] font-bold uppercase leading-tight tracking-tight text-white drop-shadow-md sm:text-[8px] sm:tracking-wider md:text-[9px] md:tracking-widest ${
+                      className={`max-w-full truncate text-center text-[8px] font-bold uppercase leading-tight tracking-[0.14em] text-white drop-shadow-md sm:text-[9px] md:text-[10px] ${
                         shouldHideClosedRailLabels
                           ? "hidden"
                           : isActionRailClosed
-                            ? "hidden md:inline"
-                            : "max-[380px]:hidden"
+                            ? "inline"
+                            : "max-[360px]:hidden"
                       }`}
                     >
                       {button.label}


### PR DESCRIPTION
### Motivation
- Improve touch-target sizing and spacing for live-card action buttons so showcase thumbnails stay icon-only without being visually cramped.
- Make action labels visible and buttons larger in full/open card mode to better match native touch expectations on mobile.
- Surface a discoverable affordance for scanned/invited flyers so tapping the hero opens the source image in a full-size preview.

### Description
- Adjusted the live-card action rail layout and closed-rail behavior in `src/components/studio/StudioLiveCardActionSurface.tsx` to avoid cramped icon grouping in showcase mode and to increase button padding and icon sizes when not in showcase mode.
- Updated action label visibility rules so labels remain readable in full/open card mode while thumbnails remain compact in showcase thumbnails.
- Enhanced `src/components/ThumbnailModal.tsx` by adding a `Maximize2` hint chip overlay, new props `showPreviewImage` and `hintLabel`, and a less intrusive default trigger styling so the control can be used as a trigger-only affordance.
- Wired the OCR/invited hero header to render the trigger-only `ThumbnailModal` in `src/app/event/[id]/page.tsx` for scanned/invited events so the hero shows an overlap hint and opens the full-size flyer image when tapped.

### Testing
- Ran `npx biome lint src/components/studio/StudioLiveCardActionSurface.tsx src/components/ThumbnailModal.tsx src/app/event/[id]/page.tsx` and it passed with no errors.
- Ran `node --test src/app/card/[id]/page.test.mjs` and it completed (no failing tests in this suite).
- Running the broader `npm run lint -- src/components/studio/StudioLiveCardActionSurface.tsx src/components/ThumbnailModal.tsx src/app/event/[id]/page.tsx` produced repo-wide lint diagnostics unrelated to these changes (generated `.next-dev-3002` artifacts and preexisting issues), not caused by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51b990e54832c988f85e4ab9ca6cd)