### PR TITLE
Add 'Snap your now.' CTA and envitefy.com link to birthday footers

### DIFF
--- a/src/components/birthdays/BirthdayRenderer.tsx
+++ b/src/components/birthdays/BirthdayRenderer.tsx
@@ -2205,6 +2205,17 @@ function EditorialFeatureLayout({
 
         <footer className="border-t border-white/70 px-1 pt-6 text-center text-sm text-slate-500">
           <p>Snapped with Envitefy.</p>
+          <p>
+            Snap your now.{" "}
+            <a
+              href="https://envitefy.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold underline decoration-2 underline-offset-2"
+            >
+              envitefy.com
+            </a>
+          </p>
         </footer>
       </main>
     </div>
@@ -2280,6 +2291,17 @@ function Footer({
       </div>
 
       <p className="text-sm opacity-60">Snapped with Envitefy.</p>
+      <p className="text-sm opacity-60">
+        Snap your now.{" "}
+        <a
+          href="https://envitefy.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold underline decoration-2 underline-offset-2"
+        >
+          envitefy.com
+        </a>
+      </p>
     </footer>
   );
 }


### PR DESCRIPTION
### Motivation
- Add a small promotional CTA beneath the existing `Snapped with Envitefy.` footer in the birthday public renderer so event pages include the `Snap your now.` copy and a hype link to `envitefy.com`, while not changing any lightbox behavior.

### Description
- Modified `src/components/birthdays/BirthdayRenderer.tsx` to insert a second footer paragraph in both footer variants with the text `Snap your now.` and an anchored `https://envitefy.com` link styled with `font-semibold` and underline classes.

### Testing
- Ran `npm run lint -- src/components/birthdays/BirthdayRenderer.tsx`, which failed due to existing repository-wide Biome diagnostics unrelated to this change, and no additional automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5200f81ac832c8be89f713b64c25c)