### PR TITLE
Make mobile Studio showcase cards full-width

### DIFF
--- a/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
+++ b/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
@@ -102,7 +102,7 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   assert.match(source, /onPointerCancelCapture=\{clearFullscreenSwipeState\}/);
   assert.match(
     source,
-    /className="no-scrollbar flex touch-auto items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-\[max\(2rem,calc\(50vw-150px\)\)\] py-8 snap-x snap-mandatory"/,
+    /className="no-scrollbar flex touch-auto items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-0 py-8 snap-x snap-mandatory sm:px-\[max\(2rem,calc\(50vw-150px\)\)\]"/,
   );
   assert.doesNotMatch(source, /w-\[calc\(50%-150px\)\] shrink-0/);
   assert.match(source, /data-showcase-active=\{activeIndex === index \? "true" : "false"\}/);
@@ -110,7 +110,7 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   assert.match(source, /import StudioShowcaseLiveCard from "@\/components\/studio\/StudioShowcaseLiveCard";/);
   assert.match(
     source,
-    /className="w-\[min\(300px,calc\(100vw-4rem\)\)\] shrink-0 snap-center cursor-pointer"/,
+    /className="w-screen shrink-0 snap-center cursor-pointer sm:w-\[min\(300px,calc\(100vw-4rem\)\)\]"/,
   );
   assert.match(source, /activeIndex === index\s*\?\s*"scale-100 opacity-100 blur-0"/);
   assert.match(source, /:\s*"scale-\[0\.85\] opacity-40 blur-\[2px\]"/);

--- a/src/app/studio/StudioMarketingPage.tsx
+++ b/src/app/studio/StudioMarketingPage.tsx
@@ -1596,7 +1596,7 @@ export default function StudioMarketingPage() {
               </div>
             </div>
 
-            <div className="relative left-1/2 mt-12 w-screen -translate-x-1/2 px-4 py-4 sm:px-6 lg:px-8">
+            <div className="relative left-1/2 mt-12 w-screen -translate-x-1/2 px-0 py-4 sm:px-6 lg:px-8">
               <div className="relative group/carousel">
                 <button
                   type="button"
@@ -1629,7 +1629,7 @@ export default function StudioMarketingPage() {
 
                 <div
                   ref={showcaseScrollRef}
-                  className="no-scrollbar flex touch-auto items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-[max(2rem,calc(50vw-150px))] py-8 snap-x snap-mandatory"
+                  className="no-scrollbar flex touch-auto items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-0 py-8 snap-x snap-mandatory sm:px-[max(2rem,calc(50vw-150px))]"
                   style={{ WebkitOverflowScrolling: "touch" }}
                 >
               {showcaseCards.map((item, index) => (
@@ -1644,7 +1644,7 @@ export default function StudioMarketingPage() {
                   data-showcase-card
                   data-showcase-card-index={index}
                   data-showcase-active={activeIndex === index ? "true" : "false"}
-                  className="w-[min(300px,calc(100vw-4rem))] shrink-0 snap-center cursor-pointer"
+                  className="w-screen shrink-0 snap-center cursor-pointer sm:w-[min(300px,calc(100vw-4rem))]"
                 >
                       <div
                         className={cx(


### PR DESCRIPTION
### Motivation

- Remove the left/right mobile padding that was cutting off Live Card Showcase cards on phones so the carousel items render edge-to-edge.
- Preserve the existing centered/insulated spacing on `sm` and larger breakpoints while making mobile UX full-bleed.

### Description

- Changed the showcase wrapper to use `px-0` on mobile while keeping `sm:px-6 lg:px-8` for larger screens in `src/app/studio/StudioMarketingPage.tsx`.
- Updated the horizontal scroll rail to `px-0` on mobile and `sm:px-[max(2rem,calc(50vw-150px))]` on larger breakpoints so centering behavior is retained.
- Made each showcase card `w-screen` on mobile and preserved the previous constrained width from `sm` upward by switching to `sm:w-[min(300px,calc(100vw-4rem))]` in `src/app/studio/StudioMarketingPage.tsx`.
- Updated the source-shape regression test `src/app/studio/StudioMarketingPage.showcase.source.test.mjs` to expect the new responsive class names.

### Testing

- Ran `node --test src/app/studio/StudioMarketingPage.showcase.source.test.mjs` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53eaf6000832c8af0d17aa83685dd)