### PR TITLE
Match /studio live card showcase sizing with /landing

### DIFF
--- a/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
+++ b/src/app/studio/StudioMarketingPage.showcase.source.test.mjs
@@ -102,7 +102,7 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   assert.match(source, /onPointerCancelCapture=\{clearFullscreenSwipeState\}/);
   assert.match(
     source,
-    /className="no-scrollbar flex touch-auto items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-0 py-8 snap-x snap-mandatory sm:px-\[max\(2rem,calc\(50vw-150px\)\)\]"/,
+    /className="no-scrollbar flex touch-auto items-start gap-4 overflow-x-auto overscroll-x-contain scroll-smooth px-\[max\(1\.25rem,calc\(50vw-136px\)\)\] py-8 snap-x snap-mandatory sm:gap-6 sm:px-\[max\(2rem,calc\(50vw-150px\)\)\]"/,
   );
   assert.doesNotMatch(source, /w-\[calc\(50%-150px\)\] shrink-0/);
   assert.match(source, /data-showcase-active=\{activeIndex === index \? "true" : "false"\}/);
@@ -110,7 +110,7 @@ test("studio marketing showcase uses a centered active-card carousel", () => {
   assert.match(source, /import StudioShowcaseLiveCard from "@\/components\/studio\/StudioShowcaseLiveCard";/);
   assert.match(
     source,
-    /className="w-screen shrink-0 snap-center cursor-pointer sm:w-\[min\(300px,calc\(100vw-4rem\)\)\]"/,
+    /className="w-\[min\(272px,calc\(100vw-5\.5rem\)\)\] shrink-0 snap-center cursor-pointer sm:w-\[min\(300px,calc\(100vw-4rem\)\)\]"/,
   );
   assert.match(source, /activeIndex === index\s*\?\s*"scale-100 opacity-100 blur-0"/);
   assert.match(source, /:\s*"scale-\[0\.85\] opacity-40 blur-\[2px\]"/);

--- a/src/app/studio/StudioMarketingPage.tsx
+++ b/src/app/studio/StudioMarketingPage.tsx
@@ -1629,7 +1629,7 @@ export default function StudioMarketingPage() {
 
                 <div
                   ref={showcaseScrollRef}
-                  className="no-scrollbar flex touch-auto items-start gap-6 overflow-x-auto overscroll-x-contain scroll-smooth px-0 py-8 snap-x snap-mandatory sm:px-[max(2rem,calc(50vw-150px))]"
+                  className="no-scrollbar flex touch-auto items-start gap-4 overflow-x-auto overscroll-x-contain scroll-smooth px-[max(1.25rem,calc(50vw-136px))] py-8 snap-x snap-mandatory sm:gap-6 sm:px-[max(2rem,calc(50vw-150px))]"
                   style={{ WebkitOverflowScrolling: "touch" }}
                 >
               {showcaseCards.map((item, index) => (
@@ -1644,7 +1644,7 @@ export default function StudioMarketingPage() {
                   data-showcase-card
                   data-showcase-card-index={index}
                   data-showcase-active={activeIndex === index ? "true" : "false"}
-                  className="w-screen shrink-0 snap-center cursor-pointer sm:w-[min(300px,calc(100vw-4rem))]"
+                  className="w-[min(272px,calc(100vw-5.5rem))] shrink-0 snap-center cursor-pointer sm:w-[min(300px,calc(100vw-4rem))]"
                 >
                       <div
                         className={cx(


### PR DESCRIPTION
### Motivation
- Align the `/studio` marketing showcase visual treatment with the `/landing` showcase so mobile cards are constrained instead of rendering full-width.

### Description
- Adjusted the showcase rail classes and padding and replaced the per-card `w-screen` with `w-[min(272px,calc(100vw-5.5rem))]` in `src/app/studio/StudioMarketingPage.tsx`, and updated the source-shape regression test in `src/app/studio/StudioMarketingPage.showcase.source.test.mjs` to assert the new class names.

### Testing
- Ran `node --test src/app/studio/StudioMarketingPage.showcase.source.test.mjs` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54f67bbbc832caeb6c96a90e45be7)