### PR TITLE
Update About, Privacy, and Terms pages for RSVP/sign-up feature

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,15 +1,15 @@
-import Link from "next/link";
 import type { Metadata } from "next";
+import Link from "next/link";
 import EnvitefyWordmark from "@/components/branding/EnvitefyWordmark";
 
 export const metadata: Metadata = {
   title: "About — Envitefy",
   description:
-    "Envitefy focuses on Snap for flyer capture and Gymnastics for meet pages and logistics.",
+    "Envitefy is a professional event platform for event creation, public event pages, RSVP and sign-up flows, and calendar-ready coordination.",
   openGraph: {
     title: "About — Envitefy",
     description:
-      "Envitefy focuses on Snap for flyer capture and Gymnastics for meet pages and logistics.",
+      "Envitefy is a professional event platform for event creation, public event pages, RSVP and sign-up flows, and calendar-ready coordination.",
     url: "https://envitefy.com/about",
     siteName: "Envitefy",
     images: [
@@ -24,30 +24,26 @@ export const metadata: Metadata = {
   },
 };
 
-const featureCards = [
+const productPillars = [
   {
-    icon: "📸",
-    title: "Snap capture",
+    title: "Event creation and publishing",
     description:
-      "Snap turns flyers, screenshots, and invites into clean event details that are ready to review and save.",
+      "Build and manage events with structured details that are clear for hosts, guests, and organizers.",
   },
   {
-    icon: "🤸",
-    title: "Gymnastics pages",
+    title: "Public event experiences",
     description:
-      "Gymnastics accounts unlock polished meet pages with session details, venue information, and parent-friendly sharing.",
+      "Deliver polished event pages with shareable links designed for modern communication and reliable updates.",
   },
   {
-    icon: "📅",
-    title: "Calendar ready",
+    title: "RSVP and sign-up flows",
     description:
-      "Dates, times, and locations stay structured so events are easy to save to Google, Apple, and Outlook.",
+      "Coordinate attendance and participant responses with streamlined workflows for social and program-based events.",
   },
   {
-    icon: "🔗",
-    title: "One clean link",
+    title: "Calendar and operational continuity",
     description:
-      "Share a page that stays current instead of passing around another screenshot, PDF, or text thread.",
+      "Keep critical event details synchronized across planning, sharing, and follow-through.",
   },
 ] as const;
 
@@ -74,85 +70,54 @@ export default function AboutPage() {
                 </span>
               </h1>
               <p className="mt-4 text-base font-medium uppercase tracking-[0.2em] text-foreground/60 sm:text-lg">
-                Snap it. Save it. Share it.
+                Professional Event Infrastructure
               </p>
               <p className="mx-auto mt-8 max-w-3xl text-lg leading-relaxed text-foreground/80 sm:text-xl">
-                Envitefy now focuses on two product surfaces: Snap for quick
-                flyer capture, and Gymnastics for meet pages and logistics.
+                Envitefy is built for teams and hosts who expect a premium standard for event
+                communication, coordination, and execution.
               </p>
             </div>
           </div>
         </div>
 
         <div className="mb-16 grid grid-cols-1 gap-6 md:grid-cols-2">
-          {featureCards.map((card) => (
+          {productPillars.map((pillar) => (
             <div
-              key={card.title}
+              key={pillar.title}
               className="rounded-2xl border border-[#e5dcff] bg-gradient-to-br from-white to-[#f8f4ff] p-6 transition-all duration-300 hover:border-[#cfc2ff] hover:shadow-lg"
             >
-              <div className="mb-3 text-4xl">{card.icon}</div>
-              <h2 className="mb-2 text-xl font-semibold text-foreground">
-                {card.title}
-              </h2>
-              <p className="leading-relaxed text-foreground/70">
-                {card.description}
-              </p>
+              <h2 className="mb-2 text-xl font-semibold text-foreground">{pillar.title}</h2>
+              <p className="leading-relaxed text-foreground/70">{pillar.description}</p>
             </div>
           ))}
         </div>
 
         <div className="mb-16 rounded-3xl border border-[#e5dcff] bg-gradient-to-br from-white to-[#f8f4ff] p-8 sm:p-10">
           <h2 className="mb-8 text-center text-3xl font-bold sm:text-4xl">
-            Why the narrower focus
+            Introducing our new capability
           </h2>
           <div className="mx-auto max-w-4xl space-y-6 text-lg leading-relaxed text-foreground/80">
             <p>
-              We built Envitefy to reduce event-entry friction for busy
-              families. The fastest path to that goal is keeping the product
-              surface smaller and clearer.
+              Envitefy now includes advanced RSVP and sign-up workflows that complement event
+              publishing and public sharing.
             </p>
             <p>
-              Snap stays available to every profile because quick capture is the
-              foundation. Gymnastics is the second live surface because meet
-              workflows need their own dedicated structure, not a generic event
-              builder.
+              This feature expands planning visibility for organizers while providing a simple and
+              dependable response experience for guests and participants.
             </p>
             <p>
-              Existing users can keep signing in. New account creation starts
-              only from the Snap or Gymnastics entry points so the right product
-              access is assigned from day one.
-            </p>
-          </div>
-        </div>
-
-        <div className="mb-16 rounded-3xl border border-[#e5dcff] bg-gradient-to-br from-white to-[#f8f4ff] p-8 sm:p-10">
-          <h2 className="mb-8 text-center text-3xl font-bold sm:text-4xl">
-            Our story
-          </h2>
-          <div className="mx-auto max-w-3xl space-y-6 text-lg leading-relaxed text-foreground/80">
-            <p>
-              We started Envitefy as parents trying to make sense of event
-              details scattered across flyers, screenshots, and chat threads.
-            </p>
-            <p>
-              The product keeps evolving, but the core standard stays the same:
-              event details should be accurate, fast to save, and easy to share.
-            </p>
-            <p>
-              That is why the product now centers on Snap and Gymnastics instead
-              of trying to market every possible event vertical at once.
+              Our product direction remains focused on quality, reliability, and elegant execution
+              across every stage of the event lifecycle.
             </p>
           </div>
         </div>
 
         <div className="text-center">
           <div className="rounded-3xl border border-[#d9ceff] bg-gradient-to-tr from-[#efe8ff] via-white to-[#f4edff] p-8 sm:p-10">
-            <h2 className="mb-4 text-3xl font-bold sm:text-4xl">
-              Pick the right starting point
-            </h2>
+            <h2 className="mb-4 text-3xl font-bold sm:text-4xl">Start with Envitefy</h2>
             <p className="mx-auto mb-8 max-w-2xl text-lg text-foreground/80">
-              New users can create an account from Snap or Gymnastics. Existing
-              users can continue logging in.
+              Choose the product surface that fits your workflow, and scale your event experience
+              with confidence.
             </p>
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
               <Link

--- a/src/app/privacy/layout.tsx
+++ b/src/app/privacy/layout.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Privacy Policy — Envitefy",
     description:
-      "This page explains the information we collect, how we use and share it, and the choices you have.",
+      "This policy summarizes how Envitefy handles account, event, RSVP, and sign-up information.",
     url: "https://envitefy.com/privacy",
     siteName: "Envitefy",
     images: [
@@ -19,10 +19,6 @@ export const metadata: Metadata = {
   },
 };
 
-export default function PrivacyLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function PrivacyLayout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -15,172 +15,59 @@ export default function PrivacyPage() {
                 </span>
               </h1>
               <p className="mt-5 text-lg sm:text-xl text-foreground/80 max-w-3xl mx-auto">
-                This page explains the information we collect, how we use and
-                share it, and the choices you have.
+                This policy summarizes what we collect, how we use it, and the choices available to
+                you.
               </p>
 
               <div className="mt-8 text-left max-w-3xl mx-auto space-y-6 text-foreground/80">
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Information we collect
-                  </h2>
+                  <h2 className="text-xl font-semibold text-foreground">Information we collect</h2>
                   <ul className="mt-2 list-disc pl-6 space-y-1">
+                    <li>Account and profile details you provide.</li>
                     <li>
-                      Account info: email and optional name details to create
-                      and manage your account.
+                      Event content, uploads, RSVP responses, and sign-up submissions processed
+                      through the platform.
                     </li>
-                    <li>
-                      Content you upload: images/PDFs to be analyzed, along with
-                      extracted text, and events/history you save in the app.
-                    </li>
-                    <li>
-                      Connected accounts: if you link with your favorite
-                      calendar service, we store the tokens needed to create
-                      calendar events on your behalf.
-                    </li>
-                    <li>
-                      Usage data: basic logs and device info to keep the service
-                      secure and reliable.
-                    </li>
+                    <li>Integration data required to connect third-party calendar services.</li>
+                    <li>Operational and security-related usage data.</li>
                   </ul>
                 </section>
 
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    How we use information
-                  </h2>
+                  <h2 className="text-xl font-semibold text-foreground">How we use information</h2>
                   <ul className="mt-2 list-disc pl-6 space-y-1">
+                    <li>Provide and improve Envitefy services.</li>
                     <li>
-                      Provide recognition and event extraction and generate
-                      `.ics` files.
+                      Power event pages, RSVP flows, and sign-up workflows, including our newer
+                      participation features.
                     </li>
-                    <li>
-                      Create calendar events in Google/Outlook when you ask us
-                      to.
-                    </li>
-                    <li>
-                      Operate, secure, troubleshoot, and improve the product.
-                    </li>
-                    <li>
-                      Communicate about your account, features, and support.
-                    </li>
+                    <li>Support integrations, account management, and support.</li>
+                    <li>Maintain security, integrity, and reliability.</li>
                   </ul>
                 </section>
 
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Event recognition and extraction
-                  </h2>
+                  <h2 className="text-xl font-semibold text-foreground">Information sharing</h2>
                   <p className="mt-2">
-                    We use event recognition to extract text from images and PDF
-                    files. The output is then processed to extract event
-                    details.
+                    We share information only as needed to provide the service, comply with legal
+                    obligations, and work with trusted infrastructure providers. We do not sell
+                    personal information.
                   </p>
                 </section>
 
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    When we share information
-                  </h2>
-                  <ul className="mt-2 list-disc pl-6 space-y-1">
-                    <li>
-                      Calendar providers: your favorite calendar service when
-                      you connect and ask us to create events.
-                    </li>
-                    <li>
-                      Service providers: hosting and infrastructure to run the
-                      service. app.
-                    </li>
-                    <li>
-                      Legal/safety: if required by law or to protect users and
-                      the service.
-                    </li>
-                  </ul>
+                  <h2 className="text-xl font-semibold text-foreground">Data management</h2>
                   <p className="mt-2">
-                    We don&apos;t sell your personal information.
+                    You may request access, correction, or deletion of eligible account data. You
+                    may also disconnect integrations at any time.
                   </p>
                 </section>
 
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Cookies
-                  </h2>
+                  <h2 className="text-xl font-semibold text-foreground">Policy updates</h2>
                   <p className="mt-2">
-                    We use necessary cookies to keep you signed in and operate
-                    the site. You can clear cookies in your browser; doing so
-                    may sign you out.
-                  </p>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Data retention &amp; deletion
-                  </h2>
-                  <p className="mt-2">
-                    We keep data for as long as needed to provide the service
-                    and comply with legal obligations. You can request deletion
-                    of your account data and disconnect calendar service at any
-                    time. Events created in your calendars via providers remain
-                    in your calendars unless you remove them there.
-                  </p>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Security
-                  </h2>
-                  <p className="mt-2">
-                    We use industry-standard measures to protect data in transit
-                    and at rest where applicable, limit access to authorized
-                    personnel, and rely on vetted providers for sensitive
-                    operations like payments and email.
-                  </p>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Children&apos;s privacy
-                  </h2>
-                  <p className="mt-2">
-                    The service isn&apos;t intended for children under 13, and
-                    we don&apos;t knowingly collect their personal information.
-                  </p>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Storage and processing
-                  </h2>
-                  <p className="mt-2">
-                    We may process and store information in the United States
-                    only.
-                  </p>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Your choices &amp; rights
-                  </h2>
-                  <ul className="mt-2 list-disc pl-6 space-y-1">
-                    <li>
-                      Access, correct, or delete your data where applicable.
-                    </li>
-                    <li>
-                      Disconnect calendar service and revoke provider access.
-                    </li>
-                    <li>Manage emails via in-message links or settings.</li>
-                    <li>Contact us to make a request or ask a question.</li>
-                  </ul>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Changes to this policy
-                  </h2>
-                  <p className="mt-2">
-                    We may update this policy by posting a new version here. If
-                    changes are material, we&apos;ll take reasonable steps to
-                    notify you.
+                    We may update this policy from time to time by publishing a revised version on
+                    this page.
                   </p>
                 </section>
               </div>

--- a/src/app/terms/layout.tsx
+++ b/src/app/terms/layout.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Terms of Use — Envitefy",
     description:
-      "By using Envitefy, you agree to these terms. Please read them carefully.",
+      "Envitefy terms covering event creation, public pages, RSVP and sign-up workflows, and platform use.",
     url: "https://envitefy.com/terms",
     siteName: "Envitefy",
     images: [
@@ -19,10 +19,6 @@ export const metadata: Metadata = {
   },
 };
 
-export default function TermsLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function TermsLayout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -15,157 +15,88 @@ export default function TermsPage() {
                 </span>
               </h1>
               <p className="mt-5 text-lg sm:text-xl text-foreground/80 max-w-3xl mx-auto">
-                By using Envitefy, you agree to these terms. Please read them
-                carefully.
+                By using Envitefy, you agree to these terms.
               </p>
 
               <div className="mt-8 text-left max-w-3xl mx-auto space-y-6 text-foreground/80">
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    What we do
-                  </h2>
+                  <h2 className="text-xl font-semibold text-foreground">Services</h2>
                   <p className="mt-2">
-                    Envitefy helps you extract event details from
-                    images/photos/pdfs and create calendar events (including
-                    `.ics` files) and optionally save them to your favorite
-                    calendar service via integrations.
+                    Envitefy provides event creation, public event pages, RSVP/sign-up workflows,
+                    and calendar-related coordination tools.
                   </p>
                 </section>
 
                 <section>
                   <h2 className="text-xl font-semibold text-foreground">
-                    Eligibility
+                    New participation features
                   </h2>
                   <p className="mt-2">
-                    You must be at least 13 years old to use the service. If you
-                    are under the age of majority where you live, use the
-                    service only with a parent/guardian&apos;s consent.
+                    Our platform includes participation workflows that allow hosts to collect RSVP
+                    and sign-up responses. You are responsible for reviewing information before
+                    publishing or sharing any event details.
                   </p>
                 </section>
 
                 <section>
                   <h2 className="text-xl font-semibold text-foreground">
-                    Your account
+                    Eligibility and account responsibility
                   </h2>
                   <p className="mt-2">
-                    Keep your account credentials secure and accurate.
-                    You&apos;re responsible for all activity under your account.
-                    Let us know if you suspect unauthorized use.
+                    You must be at least 13 years old to use the service. You are responsible for
+                    maintaining account security and for all activity under your account.
                   </p>
                 </section>
 
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Calendar integrations
-                  </h2>
-                  <p className="mt-2">
-                    If you connect with your favorite calendar service, you
-                    authorize us to create events on your behalf using their
-                    APIs. You can disconnect at any time in settings or with the
-                    providers directly. We are not affiliated with Google,
-                    Microsoft, or Apple.
-                  </p>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Your content
-                  </h2>
-                  <p className="mt-2">
-                    You own the images and information you upload. You grant us
-                    a limited license to process that content to operate,
-                    improve, and secure the service. You promise you have the
-                    rights to upload the content and that it does not violate
-                    law or others&apos; rights. Do not upload sensitive personal
-                    information unless necessary for an event you choose to
-                    store.
-                  </p>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Acceptable use
-                  </h2>
+                  <h2 className="text-xl font-semibold text-foreground">Acceptable use</h2>
                   <ul className="mt-2 list-disc pl-6 space-y-1">
                     <li>No illegal activity, harassment, or infringement.</li>
-                    <li>
-                      No attempts to disrupt, reverse engineer, or overload the
-                      service.
-                    </li>
-                    <li>No automated scraping outside documented APIs.</li>
+                    <li>No attempts to disrupt, overload, or reverse engineer the service.</li>
+                    <li>No unauthorized automation or scraping outside documented interfaces.</li>
                   </ul>
                 </section>
 
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Intellectual property
-                  </h2>
+                  <h2 className="text-xl font-semibold text-foreground">Content and rights</h2>
                   <p className="mt-2">
-                    The Envitefy app, logos, and code are our intellectual
-                    property or our licensors&apos;. Using the service
-                    doesn&apos;t give you ownership of our IP.
+                    You retain ownership of your content and grant us a limited license to process
+                    it to operate, secure, and improve the service.
+                  </p>
+                </section>
+
+                <section>
+                  <h2 className="text-xl font-semibold text-foreground">Service changes</h2>
+                  <p className="mt-2">
+                    We may modify, suspend, or discontinue features at any time, including newly
+                    introduced functionality.
                   </p>
                 </section>
 
                 <section>
                   <h2 className="text-xl font-semibold text-foreground">
-                    Service changes &amp; termination
+                    Disclaimers and limitation of liability
                   </h2>
                   <p className="mt-2">
-                    We may change or discontinue features, or suspend/terminate
-                    access for violations or risk to the service. You can stop
-                    using the service at any time.
+                    The service is provided as-is, without warranties to the extent permitted by
+                    law. To the maximum extent permitted by law, we are not liable for indirect or
+                    consequential damages.
                   </p>
                 </section>
 
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Disclaimers
-                  </h2>
+                  <h2 className="text-xl font-semibold text-foreground">Updates to these terms</h2>
                   <p className="mt-2">
-                    The service is provided &quot;as is&quot; without warranties
-                    of any kind. Event recognition and extraction may be
-                    inaccurate; always review event details before saving or
-                    sharing.
+                    We may revise these terms by publishing an updated version on this page.
+                    Continued use means acceptance of the revised terms.
                   </p>
                 </section>
 
                 <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Limitation of liability
-                  </h2>
-                  <p className="mt-2">
-                    To the maximum extent permitted by law, we are not liable
-                    for indirect, incidental, special, consequential, or
-                    punitive damages, or any loss of data, opportunities, or
-                    profits. Our total liability for any claim is limited to the
-                    amount you paid for the service in the 3 months before the
-                    event giving rise to the claim.
-                  </p>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Changes to these terms
-                  </h2>
-                  <p className="mt-2">
-                    We may update these terms by posting a new version here. If
-                    changes are material, we&apos;ll take reasonable steps to
-                    notify you. Continued use after updates means you accept the
-                    new terms.
-                  </p>
-                </section>
-
-                <section>
-                  <h2 className="text-xl font-semibold text-foreground">
-                    Contact
-                  </h2>
+                  <h2 className="text-xl font-semibold text-foreground">Contact</h2>
                   <p className="mt-2">
                     Questions? Visit our{" "}
-                    <Link
-                      href="/contact"
-                      className="underline underline-offset-4"
-                    >
+                    <Link href="/contact" className="underline underline-offset-4">
                       contact page
                     </Link>
                     .


### PR DESCRIPTION
### Motivation
- Present Envitefy in a more premium, professional voice and surface the new RSVP/sign-up participation capability in the public-facing copy. 
- Simplify and formalize privacy and terms text to cover the new participation features without adding deep technical detail.

### Description
- Rewrote the About page copy and replaced icon-driven feature cards with formal product pillars, and added explicit mention of the new RSVP/sign-up capability (`src/app/about/page.tsx`).
- Simplified the Privacy Policy content and updated it to reference account, event, RSVP, and sign-up data in a concise manner (`src/app/privacy/page.tsx`).
- Updated Terms of Use to include participation workflows and aligned legal language with the current platform scope (`src/app/terms/page.tsx`).
- Updated Open Graph metadata descriptions for About, Privacy, and Terms and adjusted layout exports formatting (`src/app/about/page.tsx`, `src/app/privacy/layout.tsx`, `src/app/terms/layout.tsx`).

### Testing
- Ran formatting with `npx biome format --write` on the touched files and the formatter updated the files successfully. 
- Ran static checks with `npx biome check` against the modified files and the checks reported no remaining issues for those files. 
- Executed `npm run lint` for validation; the lint run completed but reported unrelated, pre-existing repository-wide diagnostics (the changes here are limited to content and formatting).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec274ad6ac832cb5215b70dd43d866)