### PR TITLE
Pin image model to gpt-image-2, add model compliance checks, and normalize envitefy.com typos

### DIFF
--- a/scripts/campaign-run.test.mjs
+++ b/scripts/campaign-run.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import {
   applyCreativeQaFrameConstraints,
+  buildImageModelComplianceError,
   finalFrameIsGraphicLogoPayoff,
   inferFramePhoneDominance,
   mimeTypeForImagePath,
@@ -11,6 +12,7 @@ import {
   normalizeSocialCopyForFramePlan,
   repairStoryboardFrameBudget,
   repairStoryboardSceneSpecForBudget,
+  resolveImageModel,
   resolveRunPaths,
   validateStoryboardFrameBudget,
 } from "./lib/campaign-run.mjs";
@@ -96,6 +98,58 @@ test("normalizeCampaignInput carries reference images into the run input", () =>
   assert.equal(input.referenceImages[0].path, "reference-images/01-kitchen.png");
   assert.equal(input.looseInput.referenceImages[0].originalName, "kitchen.png");
   assert.match(input.looseInput.rawPrompt, /Reference images: kitchen\.png/);
+});
+
+test("normalizeCampaignInput normalizes envitefye.com typo to envitefy.com", () => {
+  const input = normalizeCampaignInput({
+    criteria: "Show why envitefye.com helps hosts launch quickly",
+    callToAction: "Start at envitefye.com today",
+    looseInput: {
+      extraNotes: "Never misspell envitefye.com in screen text",
+    },
+  });
+
+  assert.match(input.criteria, /envitefy\.com/);
+  assert.doesNotMatch(input.criteria, /envitefye\.com/);
+  assert.match(input.callToAction, /envitefy\.com/);
+  assert.match(input.looseInput.extraNotes, /envitefy\.com/);
+});
+
+test("resolveImageModel is pinned to gpt-image-2", () => {
+  process.env.STORYBOARD_OPENAI_IMAGE_MODEL = "gpt-image-1";
+  process.env.STUDIO_OPENAI_IMAGE_MODEL = "gpt-image-1";
+
+  assert.equal(resolveImageModel(), "gpt-image-2");
+
+  delete process.env.STORYBOARD_OPENAI_IMAGE_MODEL;
+  delete process.env.STUDIO_OPENAI_IMAGE_MODEL;
+});
+
+test("buildImageModelComplianceError returns hard blocker when effective model drifts", () => {
+  const message = buildImageModelComplianceError(
+    [
+      { frameNumber: 1, effectiveImageModel: "gpt-image-2" },
+      { frameNumber: 2, effectiveImageModel: "gpt-image-1" },
+      { frameNumber: 3, effectiveImageModel: "gpt-image-1.5" },
+    ],
+    "gpt-image-2",
+  );
+
+  assert.match(message, /Image model compliance failure/);
+  assert.match(message, /frame 2=gpt-image-1/);
+  assert.match(message, /frame 3=gpt-image-1.5/);
+});
+
+test("buildImageModelComplianceError passes when all effective models are gpt-image-2", () => {
+  const message = buildImageModelComplianceError(
+    [
+      { frameNumber: 1, effectiveImageModel: "gpt-image-2" },
+      { frameNumber: 2, effectiveImageModel: "gpt-image-2" },
+    ],
+    "gpt-image-2",
+  );
+
+  assert.equal(message, "");
 });
 
 test("mimeTypeForImagePath preserves supported reference image mime types", () => {

--- a/scripts/lib/campaign-agents.mjs
+++ b/scripts/lib/campaign-agents.mjs
@@ -2,6 +2,26 @@ function clean(value) {
   return typeof value === "string" ? value.trim() : "";
 }
 
+const CANONICAL_BRAND_DOMAIN = "envitefy.com";
+const BRAND_DOMAIN_TYPO_REGEX = /\benvitefye\.com\b/gi;
+
+function normalizeBrandDomainText(value) {
+  const text = clean(value);
+  if (!text) return text;
+  return text.replace(BRAND_DOMAIN_TYPO_REGEX, CANONICAL_BRAND_DOMAIN);
+}
+
+function normalizeBrandDomainDeep(value) {
+  if (typeof value === "string") return normalizeBrandDomainText(value);
+  if (Array.isArray(value)) return value.map((entry) => normalizeBrandDomainDeep(entry));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, normalizeBrandDomainDeep(entry)]),
+    );
+  }
+  return value;
+}
+
 function resolveJsonObject(text) {
   const raw = typeof text === "string" ? text.trim() : "";
   if (!raw) return null;
@@ -41,7 +61,8 @@ async function runStructuredStage({
     ],
   });
 
-  return resolveJsonObject(completion.choices?.[0]?.message?.content || "") || {};
+  const raw = resolveJsonObject(completion.choices?.[0]?.message?.content || "") || {};
+  return normalizeBrandDomainDeep(raw);
 }
 
 function stringArraySchema() {
@@ -528,6 +549,7 @@ export async function runBriefAgent({ client, model, campaignInput }) {
       campaignInput.tone ? `Desired tone: ${campaignInput.tone}` : "",
       campaignInput.callToAction ? `CTA: ${campaignInput.callToAction}` : "",
       campaignInput.looseInput?.extraNotes ? `Extra notes: ${campaignInput.looseInput.extraNotes}` : "",
+      "Brand naming must be exact in every field: envitefy.com (never envitefye.com or any variant).",
       "Choose one audience, one pain, one promise, and one proof moment. Do not make the brief broad or generic.",
     ],
   });

--- a/scripts/lib/campaign-run.mjs
+++ b/scripts/lib/campaign-run.mjs
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import OpenAI, { toFile } from "openai";
+import OpenAI from "openai";
 import {
   alignActionSequence,
   createFramesManifest,
@@ -115,6 +115,26 @@ function summarizeFrameCounts(frames) {
   }
 
   return summary;
+}
+
+function collectNonCompliantImageModels(frames = [], expectedModel = "gpt-image-2") {
+  const expected = clean(expectedModel).toLowerCase();
+  return (Array.isArray(frames) ? frames : [])
+    .map((frame) => ({
+      frameNumber: Number.isFinite(Number(frame?.frameNumber)) ? Math.trunc(Number(frame.frameNumber)) : 0,
+      effectiveImageModel: clean(frame?.effectiveImageModel),
+    }))
+    .filter(
+      (frame) =>
+        frame.frameNumber > 0 && frame.effectiveImageModel && frame.effectiveImageModel.toLowerCase() !== expected,
+    );
+}
+
+export function buildImageModelComplianceError(frames = [], expectedModel = "gpt-image-2") {
+  const mismatches = collectNonCompliantImageModels(frames, expectedModel);
+  if (!mismatches.length) return "";
+  const details = mismatches.map((item) => `frame ${item.frameNumber}=${item.effectiveImageModel}`).join(", ");
+  return `Image model compliance failure: expected ${expectedModel} but got ${details}.`;
 }
 
 function normalizePositiveIntegers(values = []) {
@@ -339,7 +359,26 @@ async function clearRenderedRunArtifacts(runPaths) {
   ]);
 }
 
-const IMAGE_MODEL_FALLBACK_CHAIN = ["gpt-image-2", "gpt-image-1.5", "gpt-image-1"];
+const CANONICAL_BRAND_DOMAIN = "envitefy.com";
+const BRAND_DOMAIN_TYPO_REGEX = /\benvitefye\.com\b/gi;
+const IMAGE_MODEL_FALLBACK_CHAIN = ["gpt-image-2"];
+
+function normalizeBrandDomainText(value) {
+  const text = clean(value);
+  if (!text) return text;
+  return text.replace(BRAND_DOMAIN_TYPO_REGEX, CANONICAL_BRAND_DOMAIN);
+}
+
+function normalizeBrandDomainDeep(value) {
+  if (typeof value === "string") return normalizeBrandDomainText(value);
+  if (Array.isArray(value)) return value.map((entry) => normalizeBrandDomainDeep(entry));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, normalizeBrandDomainDeep(entry)]),
+    );
+  }
+  return value;
+}
 
 function shouldRetryWithImageFallback(error) {
   const message = clean(error?.message || error);
@@ -380,15 +419,6 @@ export function mimeTypeForImagePath(filePath, fallback = "") {
   return "image/png";
 }
 
-async function toOpenAiReferenceFile(reference) {
-  const absolutePath = reference.absolutePath || reference.path;
-  const buffer = await fs.readFile(absolutePath);
-  const filename = clean(reference.originalName) || path.basename(absolutePath);
-  return toFile(buffer, filename, {
-    type: mimeTypeForImagePath(filename || absolutePath, reference.mimeType),
-  });
-}
-
 function buildReferencePrompt(prompt, referenceImages = []) {
   if (!referenceImages.length) return prompt;
   const names = referenceImages
@@ -406,29 +436,8 @@ function buildReferencePrompt(prompt, referenceImages = []) {
 
 async function generateImageBuffer({ client, requestedModel, prompt, size, user, referenceImages = [] }) {
   const resolvedReferences = normalizeReferenceImages(referenceImages);
-  if (resolvedReferences.length > 0) {
-    const uploadableReferences = await Promise.all(resolvedReferences.map(toOpenAiReferenceFile));
-    const response = await client.images.edit({
-      model: "gpt-image-1",
-      image: uploadableReferences,
-      prompt: buildReferencePrompt(prompt, resolvedReferences),
-      size,
-      quality: resolveImageQuality(),
-      background: "opaque",
-      user: clean(user) || undefined,
-      n: 1,
-    });
-    const b64 = response.data?.[0]?.b64_json || "";
-    if (!b64) throw new Error("No image payload returned from gpt-image-1 reference generation.");
-    return {
-      buffer: Buffer.from(b64, "base64"),
-      effectiveModel: "gpt-image-1",
-      warning:
-        clean(requestedModel) && clean(requestedModel) !== "gpt-image-1"
-          ? `Reference images use gpt-image-1 image edit; requested ${clean(requestedModel)}.`
-          : null,
-    };
-  }
+  const promptWithReferences =
+    resolvedReferences.length > 0 ? buildReferencePrompt(prompt, resolvedReferences) : prompt;
 
   const attempts = buildImageModelAttemptOrder(requestedModel);
   const firstModel = attempts[0];
@@ -439,7 +448,7 @@ async function generateImageBuffer({ client, requestedModel, prompt, size, user,
     try {
       const response = await client.images.generate({
         model,
-        prompt,
+        prompt: promptWithReferences,
         size,
         quality: resolveImageQuality(),
         background: "opaque",
@@ -472,7 +481,7 @@ export function resolveTextModel() {
 }
 
 export function resolveImageModel() {
-  return process.env.STORYBOARD_OPENAI_IMAGE_MODEL || process.env.STUDIO_OPENAI_IMAGE_MODEL || "gpt-image-2";
+  return "gpt-image-2";
 }
 
 export function resolveImageQuality() {
@@ -524,20 +533,22 @@ function normalizeOverrideBlock(rawInput = {}) {
 }
 
 export function normalizeCampaignInput(rawInput = {}) {
-  const input = asObject(rawInput);
-  const criteria =
+  const input = normalizeBrandDomainDeep(asObject(rawInput));
+  const criteria = normalizeBrandDomainText(
     clean(input.criteria) ||
-    clean(input.prompt) ||
-    clean(input.rawPrompt) ||
-    clean(input.looseInput?.rawPrompt);
-  const productName = clean(input.productName);
+      clean(input.prompt) ||
+      clean(input.rawPrompt) ||
+      clean(input.looseInput?.rawPrompt),
+  );
+  const productName = normalizeBrandDomainText(clean(input.productName));
   const targetVertical = clean(input.targetVertical);
   const tone = clean(input.tone);
-  const callToAction = clean(input.callToAction || input.cta);
+  const callToAction = normalizeBrandDomainText(clean(input.callToAction || input.cta));
   const jobLabel = clean(input.jobLabel || input.job);
   const outputRoot = clean(input.outputRoot);
-  const extraNotes =
-    clean(input.notes) || clean(input.extraNotes) || clean(input.looseInput?.extraNotes);
+  const extraNotes = normalizeBrandDomainText(
+    clean(input.notes) || clean(input.extraNotes) || clean(input.looseInput?.extraNotes),
+  );
   const overrides = normalizeOverrideBlock(input);
   const referenceImages = normalizeReferenceImages(input.referenceImages || input.looseInput?.referenceImages);
   const rawPrompt = [
@@ -552,11 +563,11 @@ export function normalizeCampaignInput(rawInput = {}) {
     .join("\n");
 
   return {
-    criteria,
-    productName,
+    criteria: normalizeBrandDomainText(criteria),
+    productName: normalizeBrandDomainText(productName),
     targetVertical,
     tone,
-    callToAction,
+    callToAction: normalizeBrandDomainText(callToAction),
     jobLabel,
     outputRoot,
     referenceImages,
@@ -1584,6 +1595,11 @@ async function generateStoryboardImagesForRun({
       await fs.writeFile(outputPath, imageResult.buffer);
       frame.status = "done";
       frame.effectiveImageModel = imageResult.effectiveModel;
+      const modelComplianceError = buildImageModelComplianceError([frame], "gpt-image-2");
+      if (modelComplianceError) {
+        frame.status = "error";
+        frame.error = modelComplianceError;
+      }
     } catch (error) {
       frame.status = "error";
       frame.error = error instanceof Error ? error.message : "Image generation failed.";
@@ -1595,6 +1611,16 @@ async function generateStoryboardImagesForRun({
   }
 
   const hadError = framesManifest.frames.some((frame) => frame.status === "error");
+  const modelComplianceError = buildImageModelComplianceError(framesManifest.frames, "gpt-image-2");
+  if (modelComplianceError) {
+    setStageStatus(statusDoc, "image-generation", "error", {
+      error: modelComplianceError,
+    });
+    statusDoc.error = modelComplianceError;
+    await persistStatus("Image generation failed model compliance checks", "error", "image-generation");
+    throw new Error(statusDoc.error);
+  }
+
   if (hadError) {
     setStageStatus(statusDoc, "image-generation", "error", {
       error: "One or more storyboard frames failed to generate.",


### PR DESCRIPTION
### Motivation

- Ensure all generated copy and structured outputs use the canonical brand domain `envitefy.com` by normalizing common typos.  
- Prevent runs from silently using non-compliant image models by pinning the effective image model to `gpt-image-2` and surfacing hard errors when model drift occurs.  
- Simplify image generation model fallback behavior and tighten prompt/reference handling to avoid unexpected edits or model mismatches.

### Description

- Added brand-domain normalization utilities (`normalizeBrandDomainText`, `normalizeBrandDomainDeep`) and applied them to the structured agents pipeline (`runStructuredStage`) and campaign input normalization (`normalizeCampaignInput`).
- Pinned the resolved image model via `resolveImageModel()` to always return `gpt-image-2` and reduced `IMAGE_MODEL_FALLBACK_CHAIN` to `["gpt-image-2"]` to remove fallbacks.
- Introduced model compliance helpers `collectNonCompliantImageModels()` and `buildImageModelComplianceError()` and integrated per-frame and run-level checks that mark frames/runs as errors when effective image models differ from `gpt-image-2`.
- Adjusted image generation flow: consolidated prompt-with-references handling into `generateImageBuffer()` and removed the previous file-upload/edit path that used `toFile`/`images.edit` in favor of the unified `images.generate` flow.
- Updated imports to remove `toFile` usage and added related functions/exports to `campaign-run.mjs` and `campaign-agents.mjs`.
- Added unit tests to `scripts/campaign-run.test.mjs` for brand-domain normalization, `resolveImageModel`, and `buildImageModelComplianceError`, and kept existing tests for image mime type and social copy behaviors.

### Testing

- Ran the unit test suite `scripts/campaign-run.test.mjs`, including new tests `normalizeCampaignInput normalizes envitefye.com typo to envitefy.com`, `resolveImageModel is pinned to gpt-image-2`, and `buildImageModelComplianceError` variants, and all tests passed.  
- Existing tests for `mimeTypeForImagePath` and social-copy padding were exercised and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2d9962d0832caab02413a88b4471)