### PR TITLE
Persist generated Studio images and prefer `imageUrl` over inline `imageDataUrl`

### DIFF
--- a/docs/studio-flow-diagnosis.md
+++ b/docs/studio-flow-diagnosis.md
@@ -1,0 +1,73 @@
+# Studio Frame Flow Diagnosis (10-frame sequence)
+
+## Score (1-10)
+
+**Current flow score: 6.5 / 10**
+
+The narrative arc is mostly coherent, but execution quality and conversion clarity are inconsistent in ways that make the flow feel "almost good" instead of convincing.
+
+## Why the flow feels like a struggle
+
+### 1) Caption layer is visibly breaking trust
+In multiple frames, caption text appears clipped/truncated (for example, partial phrases like "time's ticking, no i", "searching for a qui", "everyone's impress:", "peace returns to p;").
+
+That creates a strong "unfinished" signal and hurts perceived product quality more than almost any other issue in the sequence.
+
+### 2) Repetition without enough progression
+The same kitchen environment and very similar character poses are reused heavily. The arc has the right beats (stress → solution → relief), but visual deltas between adjacent frames are often too small.
+
+Result: viewers may feel stuck in one moment instead of experiencing momentum.
+
+### 3) Story objective drifts between emotional and product proof
+Some frames are emotional beats (pressure, confidence), while others are product proof shots (phone UI, send-ready state). Both are valid, but the transitions are not always explicit.
+
+Without clearer transitions, the sequence can feel like two different stories interleaved.
+
+### 4) Camera language is described but not always differentiated enough
+The metadata says different camera intents (observational, over-shoulder, close-up, etc.), but the rendered framing often lands in a similar medium-shot feel.
+
+This weakens rhythm and lowers perceived cinematic intent.
+
+### 5) Status UX communicates unfinished output
+Every frame shows "pending · unsaved" while also displaying "DONE". That contradiction undermines confidence and makes users feel they are still in a draft/debug state.
+
+### 6) Payoff is present but not sharply escalated
+Frames 8-10 are the payoff phase, but the emotional lift is modest. The "Ready to host" end state needs a clearer contrast from frame 1 stress to feel earned.
+
+## What is working
+
+- The 10-frame scaffold is structurally solid.
+- Character continuity is good.
+- Product proof inserts (phone invite screens) are directionally correct.
+- The narrative intent is understandable without extra explanation.
+
+## Highest-impact fixes (in order)
+
+1. **Fix caption truncation and enforce deterministic text fitting**  
+   Hard gate: no clipped text can ship.
+2. **Increase per-frame visual delta for frames 2-4 and 8-10**  
+   Enforce shot progression rules (distance, angle, action change).
+3. **Add explicit transition beats between emotion and product proof**  
+   Example: stress trigger → digital alternative discovered → proof screen.
+4. **Resolve status-state contradiction**  
+   Replace "pending · unsaved" when frame is marked done.
+5. **Strengthen the final payoff contrast**  
+   Make frame 10 unmistakably calmer/more social/successful than frame 1.
+
+## Practical acceptance checklist for "good flow"
+
+A sequence is "good" only when all are true:
+
+- No clipped text anywhere.
+- Each frame has one unique narrative job.
+- Consecutive frames differ by obvious camera/action change.
+- Product proof appears at least twice, clearly readable.
+- Final emotional state is visibly different from opening stress state.
+- UI labels do not conflict (no done/pending mismatch).
+
+## Short diagnosis
+
+You are not struggling because the concept is weak.
+You are struggling because **execution reliability and progression control** are not strict enough yet.
+
+The flow engine is close; the finishing constraints are what need tightening.

--- a/src/app/api/studio/generate/route.ts
+++ b/src/app/api/studio/generate/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "@/lib/auth";
 import { generateStudioInvitation } from "@/lib/studio/generate";
 import { resolveStudioProvider } from "@/lib/studio/provider";
 import { parseStudioGenerateRequest, type StudioGenerateFailureResponse } from "@/lib/studio/types";
+import { processBufferUpload } from "@/lib/media-upload";
+import { parseDataUrlBase64 } from "@/utils/data-url";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,6 +24,7 @@ function buildFailureResponse(
       liveCard: null,
       invitation: null,
       imageDataUrl: null,
+      imageUrl: null,
       warnings: [],
       errors: {
         text: {
@@ -57,7 +60,46 @@ export async function POST(request: Request) {
     }
 
     const result = await generateStudioInvitation(parsed.value);
-    return NextResponse.json(result, { status: 200 });
+    if (!result.imageDataUrl) {
+      return NextResponse.json(result, { status: 200 });
+    }
+
+    const parsedImage = parseDataUrlBase64(result.imageDataUrl);
+    if (!parsedImage) {
+      return NextResponse.json(
+        {
+          ...result,
+          warnings: [...result.warnings, "Generated image could not be persisted; using inline image."],
+        },
+        { status: 200 },
+      );
+    }
+
+    try {
+      const uploaded = await processBufferUpload({
+        bytes: Buffer.from(parsedImage.base64Payload, "base64"),
+        fileName: "studio-generated-image.png",
+        mimeType: parsedImage.mimeType || "image/png",
+        usage: "header",
+      });
+
+      return NextResponse.json(
+        {
+          ...result,
+          imageUrl: uploaded.stored.display?.url || uploaded.stored.source?.url || null,
+          imageDataUrl: null,
+        },
+        { status: 200 },
+      );
+    } catch {
+      return NextResponse.json(
+        {
+          ...result,
+          warnings: [...result.warnings, "Generated image persistence failed; using inline image."],
+        },
+        { status: 200 },
+      );
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : "Internal server error";
     return buildFailureResponse(500, "internal_error", message || "Internal server error", true);

--- a/src/app/studio/StudioWorkspace.live-card-edit.source.test.mjs
+++ b/src/app/studio/StudioWorkspace.live-card-edit.source.test.mjs
@@ -28,7 +28,7 @@ test("live card updates reuse the current image in the studio generation request
   );
   assert.match(
     source,
-    /response\.imageDataUrl \|\| existingItem\?\.url \|\| getFallbackThumbnail\(currentDetails\)/,
+    /response\.imageUrl \|\|\s*response\.imageDataUrl \|\|\s*existingItem\?\.url \|\|\s*getFallbackThumbnail\(currentDetails\)/,
   );
   assert.match(source, /persistStudioLibraryImageUrl/);
   assert.match(

--- a/src/app/studio/StudioWorkspace.tsx
+++ b/src/app/studio/StudioWorkspace.tsx
@@ -176,6 +176,7 @@ async function persistStudioLibraryImageUrl(
 ): Promise<string | undefined> {
   const u = clean(url);
   if (!u) return undefined;
+  if (!u.startsWith("data:image/")) return u;
   try {
     const persisted = await persistImageMediaValue({
       value: u,
@@ -1348,7 +1349,10 @@ export default function StudioWorkspace() {
       setGenerationNote(response.themeNormalization?.note || null);
       const generatedDetails = response.preparedDetails || currentDetails;
       const rawUrl =
-        response.imageDataUrl || existingItem?.url || getFallbackThumbnail(currentDetails);
+        response.imageUrl ||
+        response.imageDataUrl ||
+        existingItem?.url ||
+        getFallbackThumbnail(currentDetails);
       const persistedUrl = await persistStudioLibraryImageUrl(
         { ...loadingItem, status: "ready", url: rawUrl },
         rawUrl,
@@ -1416,7 +1420,7 @@ export default function StudioWorkspace() {
       );
       setGenerationNote(response.themeNormalization?.note || null);
 
-      const rawEditUrl = response.imageDataUrl || savedItem.url;
+      const rawEditUrl = response.imageUrl || response.imageDataUrl || savedItem.url;
       const persistedEditUrl = await persistStudioLibraryImageUrl(
         { ...savedItem, url: rawEditUrl },
         rawEditUrl,

--- a/src/app/studio/studio-workspace-sanitize.ts
+++ b/src/app/studio/studio-workspace-sanitize.ts
@@ -556,6 +556,7 @@ export function sanitizeStudioGenerateResponse(value: unknown): StudioGenerateAp
     typeof value.imageDataUrl === "string" && value.imageDataUrl.startsWith("data:image/")
       ? value.imageDataUrl
       : null;
+  const imageUrl = typeof value.imageUrl === "string" && value.imageUrl.trim() ? value.imageUrl : null;
   const themeNormalization = normalizeStudioThemeNormalization(value.themeNormalization);
   const warnings = Array.isArray(value.warnings)
     ? value.warnings.map(readString).filter(Boolean).slice(0, 8)
@@ -580,13 +581,14 @@ export function sanitizeStudioGenerateResponse(value: unknown): StudioGenerateAp
       liveCard: null,
       invitation: null,
       imageDataUrl: null,
+      imageUrl: null,
       themeNormalization,
       warnings,
       errors,
     };
   }
 
-  if (!liveCard && !invitation && !imageDataUrl) return null;
+  if (!liveCard && !invitation && !imageDataUrl && !imageUrl) return null;
 
   return {
     ok: true,
@@ -594,6 +596,7 @@ export function sanitizeStudioGenerateResponse(value: unknown): StudioGenerateAp
     liveCard,
     invitation: invitation || liveCard?.invitation || null,
     imageDataUrl,
+    imageUrl,
     themeNormalization,
     warnings,
     errors,

--- a/src/lib/studio/generate.ts
+++ b/src/lib/studio/generate.ts
@@ -171,7 +171,14 @@ export async function generateStudioInvitation(
   }
 
   const hasErrors = Boolean(errors.text || errors.image);
-  const ok = !hasErrors && (invitation !== null || imageDataUrl !== null);
+  const hasTextSuccess = invitation !== null;
+  const hasImageSuccess = imageDataUrl !== null;
+  const ok =
+    mode === "text"
+      ? hasTextSuccess
+      : mode === "image"
+        ? hasImageSuccess
+        : hasTextSuccess || hasImageSuccess;
 
   return {
     ok,

--- a/src/lib/studio/types.ts
+++ b/src/lib/studio/types.ts
@@ -119,6 +119,7 @@ export type StudioGenerateResponse = {
   liveCard: StudioLiveCardMetadata | null;
   invitation: StudioInvitationText | null;
   imageDataUrl: string | null;
+  imageUrl?: string | null;
   themeNormalization?: StudioThemeNormalization | null;
   warnings: string[];
   errors?: {
@@ -133,6 +134,7 @@ export type StudioGenerateFailureResponse = {
   liveCard: null;
   invitation: null;
   imageDataUrl: null;
+  imageUrl?: string | null;
   themeNormalization?: StudioThemeNormalization | null;
   warnings: string[];
   errors: {


### PR DESCRIPTION
### Motivation

- Ensure generated invitation images are persisted to storage instead of relying on inline `data:` URLs to improve reliability and CDN delivery.
- Surface a stable `imageUrl` in responses so the client can use hosted assets and avoid large inline payloads.
- Make the Studio workspace and sanitization logic handle both inline and persisted images consistently.

### Description

- Updated the server generation route (`src/app/api/studio/generate/route.ts`) to parse `imageDataUrl`, upload the decoded buffer via `processBufferUpload`, and return an `imageUrl` (and clear `imageDataUrl`) when persistence succeeds, with fallbacks and warnings on failure.
- Added `imageUrl` to the studio types (`src/lib/studio/types.ts`) and extended response sanitization (`src/app/studio/studio-workspace-sanitize.ts`) to accept and validate `imageUrl` alongside `imageDataUrl`.
- Adjusted generation logic (`src/lib/studio/generate.ts`) to compute `ok` based on the requested `mode` so text-only/image-only/both modes are evaluated correctly for success.
- Updated Studio UI and persistence logic (`src/app/studio/StudioWorkspace.tsx`) to prefer `response.imageUrl` over inline `imageDataUrl`, to skip re-persisting already-hosted URLs, and to persist only when the URL is a `data:image/*` payload; also added minor flow handling for edited images and preview state.
- Updated unit/source tests (`src/app/studio/StudioWorkspace.live-card-edit.source.test.mjs`) to expect the new `response.imageUrl` precedence and added a diagnostic doc (`docs/studio-flow-diagnosis.md`) with flow recommendations.

### Testing

- Ran the updated unit test `StudioWorkspace.live-card-edit.source.test.mjs`, which passed after updating the expected source patterns to include `response.imageUrl` precedence.
- Ran the project test suite and type checks locally; the test suite passed and type checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee727bbddc832cb2c2775179d747a5)