### PR TITLE
Add Graduation skin for scanned invites and improve OCR graduation detection

### DIFF
--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -10,6 +10,7 @@ import { cache } from "react";
 import AccessCodeGate from "@/components/AccessCodeGate";
 import AppleCalendarLink from "@/components/AppleCalendarLink";
 import BirthdaySkin from "@/components/BirthdaySkin";
+import GraduationSkin from "@/components/GraduationSkin";
 import ScannedInviteSkin from "@/components/ScannedInviteSkin";
 import { BIRTHDAY_THEMES } from "@/components/birthdays/birthdayThemes";
 import {
@@ -1575,6 +1576,69 @@ export default async function EventPage({
         ? ((data as any).attire as string).trim()
         : null;
     const scannedInviteRegistryUrl = registryLinks[0]?.url || null;
+    const scannedInviteActions =
+      !isReadOnly &&
+      isOwner && (
+        <div className="flex items-center gap-2 sm:gap-3 text-sm font-medium">
+          {canManageCreatedEvent && (
+            <Link
+              href={buildEditLink(row.id, data, title)}
+              className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-sm text-neutral-800/80 transition-colors hover:bg-black/5 hover:text-neutral-900"
+              title="Edit event"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-4 w-4"
+              >
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+              </svg>
+              <span className="hidden sm:inline">Edit</span>
+            </Link>
+          )}
+          <EventDeleteModal eventId={row.id} eventTitle={title} />
+          <EventActions
+            shareUrl={shareUrl}
+            event={data as any}
+            calendarTitle={title}
+            historyId={!isReadOnly ? row.id : undefined}
+            className=""
+            variant="compact"
+            tone={"default" as any}
+            showCalendar={false}
+            showEmail={false}
+          />
+        </div>
+      );
+
+    if (categoryNormalized === "graduations") {
+      return (
+        <GraduationSkin
+          title={title}
+          dateLabel={formattedTimeAndDate.date || whenLabel || null}
+          timeLabel={formattedTimeAndDate.time || null}
+          location={locationText || venueText || null}
+          imageUrl={scannedInviteImageUrl}
+          calendarLinks={calendarLinks}
+          palette={ocrSkin?.palette || null}
+          rsvpName={rsvpName}
+          rsvpPhone={rsvpPhone}
+          rsvpEmail={rsvpEmail}
+          rsvpUrl={rsvpUrl}
+          detailCopy={scannedInviteDetailCopy}
+          activities={scannedInviteActivities}
+          attire={scannedInviteAttire}
+          registryUrl={scannedInviteRegistryUrl}
+          actions={scannedInviteActions}
+        />
+      );
+    }
 
     return (
       <ScannedInviteSkin
@@ -1594,47 +1658,7 @@ export default async function EventPage({
         activities={scannedInviteActivities}
         attire={scannedInviteAttire}
         registryUrl={scannedInviteRegistryUrl}
-        actions={
-          !isReadOnly &&
-          isOwner && (
-            <div className="flex items-center gap-2 sm:gap-3 text-sm font-medium">
-              {canManageCreatedEvent && (
-                <Link
-                  href={buildEditLink(row.id, data, title)}
-                  className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-sm text-neutral-800/80 transition-colors hover:bg-black/5 hover:text-neutral-900"
-                  title="Edit event"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="h-4 w-4"
-                  >
-                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-                  </svg>
-                  <span className="hidden sm:inline">Edit</span>
-                </Link>
-              )}
-              <EventDeleteModal eventId={row.id} eventTitle={title} />
-              <EventActions
-                shareUrl={shareUrl}
-                event={data as any}
-                calendarTitle={title}
-                historyId={!isReadOnly ? row.id : undefined}
-                className=""
-                variant="compact"
-                tone={"default" as any}
-                showCalendar={false}
-                showEmail={false}
-              />
-            </div>
-          )
-        }
+        actions={scannedInviteActions}
       />
     );
   }

--- a/src/components/GraduationSkin.tsx
+++ b/src/components/GraduationSkin.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import type { ReactNode } from "react";
+import ScannedInviteSkin from "@/components/ScannedInviteSkin";
+
+type CalendarLinks = {
+  google: string;
+  outlook: string;
+  appleInline: string;
+};
+
+type Palette = {
+  background?: string;
+  primary?: string;
+  secondary?: string;
+  accent?: string;
+  text?: string;
+  dominant?: string;
+  themeColor?: string;
+} | null;
+
+type Props = {
+  title: string;
+  dateLabel?: string | null;
+  timeLabel?: string | null;
+  location?: string | null;
+  imageUrl?: string | null;
+  calendarLinks?: CalendarLinks | null;
+  palette?: Palette;
+  rsvpName?: string | null;
+  rsvpPhone?: string | null;
+  rsvpEmail?: string | null;
+  rsvpUrl?: string | null;
+  detailCopy?: string | null;
+  activities?: string[] | null;
+  attire?: string | null;
+  registryUrl?: string | null;
+  actions?: ReactNode;
+};
+
+export default function GraduationSkin({
+  title,
+  dateLabel,
+  timeLabel,
+  location,
+  imageUrl,
+  calendarLinks,
+  palette,
+  rsvpName,
+  rsvpPhone,
+  rsvpEmail,
+  rsvpUrl,
+  detailCopy,
+  activities,
+  attire,
+  registryUrl,
+  actions,
+}: Props) {
+  const graduationPalette = {
+    background: palette?.background || "#f6f2ff",
+    primary: palette?.primary || "#5b3cc4",
+    secondary: palette?.secondary || "#7c5cff",
+    accent: palette?.accent || "#f4b942",
+    text: palette?.text || "#1f1633",
+    dominant: palette?.dominant || "#5b3cc4",
+    themeColor: palette?.themeColor || "#5b3cc4",
+  };
+  const graduationActivities =
+    Array.isArray(activities) && activities.length
+      ? activities
+      : ["Commencement", "Photo Moments", "Celebration Gathering"];
+
+  return (
+    <ScannedInviteSkin
+      title={title}
+      categoryLabel="🎓 Graduation Celebration"
+      dateLabel={dateLabel}
+      timeLabel={timeLabel}
+      location={location}
+      imageUrl={imageUrl}
+      calendarLinks={calendarLinks}
+      palette={graduationPalette}
+      rsvpName={rsvpName}
+      rsvpPhone={rsvpPhone}
+      rsvpEmail={rsvpEmail}
+      rsvpUrl={rsvpUrl}
+      detailCopy={
+        detailCopy ||
+        "Join us to honor the graduate, celebrate this milestone, and capture memories together."
+      }
+      activities={graduationActivities}
+      attire={attire || "Grad celebration attire"}
+      registryUrl={registryUrl}
+      actions={actions}
+    />
+  );
+}

--- a/src/lib/ocr/text.test.ts
+++ b/src/lib/ocr/text.test.ts
@@ -39,6 +39,7 @@ test("detectCategory recognizes expanded invite categories", () => {
   assert.equal(detectCategory("Join us for Ava's Baby Shower brunch"), "Baby Showers");
   assert.equal(detectCategory("Olivia's Bridal Shower at Magnolia House"), "Bridal Showers");
   assert.equal(detectCategory("Class of 2026 Graduation Party"), "Graduations");
+  assert.equal(detectCategory("Graduation Ceremony — Lena De La Cruz"), "Graduations");
   assert.equal(detectCategory("You're invited to our neighborhood fundraiser gala"), "General Events");
 });
 

--- a/src/lib/ocr/text.ts
+++ b/src/lib/ocr/text.ts
@@ -747,9 +747,11 @@ export function detectCategory(fullText: string): string | null {
     if (hasAppt) return "Appointments";
 
     if (/\bbridal\s*shower\b/i.test(fullText)) return "Bridal Showers";
+    const hasGraduation = /(graduation|grad\s*party|commencement|class of\s+\d{4})/i.test(fullText);
     const hasWedding =
       /(wedding|marriage|marieage|ceremony|reception|bride|groom|nupti(al)?|bridal)/i.test(fullText);
     const hasBirthday = /(birthday\s*party|\b(b-?day)\b|\bturns?\s+\d+|\bbirthday\b)/i.test(fullText);
+    if (hasGraduation) return "Graduations";
     if (hasWedding && !hasBirthday) return "Weddings";
     if (hasBirthday && !hasWedding) return "Birthdays";
     if (/(baby\s*shower|baby\s*sprinkle|gender\s*reveal|sip\s*(and|&)\s*see)/i.test(fullText)) {
@@ -759,9 +761,6 @@ export function detectCategory(fullText: string): string | null {
       return "Engagements";
     }
     if (/(anniversary|vow\s*renewal)/i.test(fullText)) return "Anniversaries";
-    if (/(graduation|grad\s*party|commencement|class of\s+\d{4})/i.test(fullText)) {
-      return "Graduations";
-    }
     if (
       /(baptism|christening|communion|first holy communion|confirmation|bar mitzvah|bat mitzvah|baby dedication)/i.test(
         fullText,


### PR DESCRIPTION
### Motivation

- Provide a dedicated visual skin for graduation-related scanned invites to present a tailored experience for graduation events.
- Reduce duplicated action markup by centralizing the owner/action controls for scanned-invite skins so multiple skins can reuse the same UI.

### Description

- Add a new client component `GraduationSkin` in `src/components/GraduationSkin.tsx` which wraps `ScannedInviteSkin` with graduation-specific palette, default copy, and activities.
- Import and use `GraduationSkin` in `src/app/event/[id]/page.tsx` and render it when `categoryNormalized === "graduations"` for scanned-invite events.
- Extract the owner/action controls into a shared `scannedInviteActions` variable in `page.tsx` and pass it to both `ScannedInviteSkin` and `GraduationSkin` to avoid duplicated JSX.
- Improve OCR category detection in `src/lib/ocr/text.ts` by detecting graduation-related phrases earlier, and add a corresponding assertion to `src/lib/ocr/text.test.ts` to cover the new detection.

### Testing

- Ran unit tests with `yarn test` which included the OCR text detection suite, and all tests passed. 
- The updated `detectCategory` behavior is covered by `src/lib/ocr/text.test.ts` and the new assertion for graduation detection succeeded. 
- Type checking and component compilation were validated via the project test run with no type errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb0d9c2d0832cb0c4af54c9a3f31a)