### PR TITLE
Add share/delete quick actions for invited and snapped/uploaded events

### DIFF
--- a/src/app/left-sidebar.controller.ts
+++ b/src/app/left-sidebar.controller.ts
@@ -141,6 +141,8 @@ export type LeftSidebarControllerViewModel = {
   isCompactNavActive: (id: CompactNavItemId) => boolean;
   openOwnerEventContext: (item: GroupedEventItem) => void;
   openGuestEventContext: (item: GroupedEventItem) => void;
+  shareEventFromList: (item: GroupedEventItem) => Promise<void>;
+  deleteEventFromList: (item: GroupedEventItem) => Promise<void>;
   isHistoryRowActive: (rowId: string) => boolean;
   handleEventTabChange: (tab: EventContextTab) => void;
   handleSidebarBackToEvents: () => void;
@@ -1265,6 +1267,42 @@ export function useLeftSidebarController({
     ]
   );
 
+  const shareEventFromList = useCallback(async (item: GroupedEventItem) => {
+    const eventTitle = item?.title || item?.row?.title || "Event";
+    const eventHref = item?.href || `/event/${item?.row?.id || ""}`;
+    const eventUrl = new URL(eventHref, window.location.origin).toString();
+    if ((navigator as any).share) {
+      await (navigator as any).share({
+        title: eventTitle,
+        text: `Join me at ${eventTitle}`,
+        url: eventUrl,
+      });
+      return;
+    }
+    await navigator.clipboard.writeText(eventUrl);
+  }, []);
+
+  const deleteEventFromList = useCallback(
+    async (item: GroupedEventItem) => {
+      const eventId = String(item?.row?.id || "").trim();
+      if (!eventId) return;
+      const eventLabel = item?.title || item?.row?.title || "Untitled event";
+      const ok = window.confirm(
+        `Are you sure you want to delete this event?\n\n${eventLabel}`
+      );
+      if (!ok) return;
+      const response = await fetch(`/api/history/${eventId}`, { method: "DELETE" });
+      if (!response.ok) {
+        throw new Error("Failed to delete event");
+      }
+      window.dispatchEvent(new CustomEvent("history:deleted", { detail: { id: eventId } }));
+      if (selectedEventId === eventId) {
+        clearEventContext();
+      }
+    },
+    [clearEventContext, selectedEventId]
+  );
+
   const isHistoryRowActive = useCallback(
     (rowId: string) => {
       if (!rowId) return false;
@@ -1392,6 +1430,8 @@ export function useLeftSidebarController({
     isCompactNavActive,
     openOwnerEventContext,
     openGuestEventContext,
+    shareEventFromList,
+    deleteEventFromList,
     isHistoryRowActive,
     handleEventTabChange,
     handleSidebarBackToEvents,

--- a/src/app/left-sidebar.model.ts
+++ b/src/app/left-sidebar.model.ts
@@ -42,6 +42,7 @@ export type GroupedEventItem = {
   row: HistoryRow;
   href: string;
   openMode: "dashboard" | "preview";
+  showQuickActions: boolean;
   title: string;
   dateLabel: string;
   dateMs: number;
@@ -683,6 +684,17 @@ export function buildGroupedEventLists(args: {
         : rawShareStatus === "pending"
           ? "pending"
           : null;
+    const createdVia = String(
+      data?.createdVia ||
+        data?.source ||
+        data?.ingestMethod ||
+        data?.origin ||
+        "",
+    )
+      .trim()
+      .toLowerCase();
+    const isSnappedOrUploaded =
+      Boolean(data?.invitedFromScan) || /(snap|scan|ocr|upload)/.test(createdVia);
 
     const categoryColor = defaultCategoryColor(category);
     const palette = colorClasses(isInvited ? "slate" : categoryColor);
@@ -700,6 +712,7 @@ export function buildGroupedEventLists(args: {
       row,
       href,
       openMode,
+      showQuickActions: isInvited || isSnappedOrUploaded,
       title: row.title || "Untitled event",
       dateLabel,
       dateMs,

--- a/src/app/left-sidebar.tsx
+++ b/src/app/left-sidebar.tsx
@@ -37,8 +37,10 @@ import {
   Stethoscope,
   WandSparkles,
   Trophy,
+  Trash2,
   Upload,
   User,
+  Share2,
   Users,
 } from "lucide-react";
 import { useSidebar } from "./sidebar-context";
@@ -712,6 +714,8 @@ function EventListPanel({
   emptyPastCopy,
   isHistoryRowActive,
   onRowClick,
+  onShareRow,
+  onDeleteRow,
   pastExpanded,
   setPastExpanded,
   showPendingBadge,
@@ -724,6 +728,8 @@ function EventListPanel({
   emptyPastCopy: string;
   isHistoryRowActive: (rowId: string) => boolean;
   onRowClick: (item: GroupedEventItem) => void;
+  onShareRow: (item: GroupedEventItem) => Promise<void> | void;
+  onDeleteRow: (item: GroupedEventItem) => Promise<void> | void;
   pastExpanded: boolean;
   setPastExpanded: Dispatch<SetStateAction<boolean>>;
   showPendingBadge: boolean;
@@ -732,28 +738,47 @@ function EventListPanel({
 }) {
   const renderRows = (items: GroupedEventItem[], muted: boolean) =>
     items.map((item) => (
-      <button
+      <div
         key={item.row.id}
-        type="button"
-        onClick={() => onRowClick(item)}
         className={`${SIDEBAR_SUBMENU_ROW_CLASS} items-start px-2 py-2.5 ${
           isHistoryRowActive(item.row.id)
             ? SIDEBAR_SUBMENU_ROW_ACTIVE_CLASS
             : SIDEBAR_SUBMENU_ROW_INACTIVE_CLASS
         } ${muted ? pastRowOpacityClass : ""}`}
       >
-        <span
-          className={`${SIDEBAR_SUBMENU_ICON_CLASS} mt-0.5 ${
-            isHistoryRowActive(item.row.id)
-              ? SIDEBAR_SUBMENU_ICON_ACTIVE_CLASS
-              : `${item.tintClass} ${SIDEBAR_SUBMENU_ICON_INACTIVE_CLASS}`
-          }`}
+        <button
+          type="button"
+          onClick={() => onRowClick(item)}
+          className="flex min-w-0 flex-1 items-start gap-3 text-left"
         >
-          <CalendarDays size={16} />
-        </span>
-        <span className="min-w-0 flex-1">
-          {showPendingBadge ? (
-            <span className="flex items-center gap-2">
+          <span
+            className={`${SIDEBAR_SUBMENU_ICON_CLASS} mt-0.5 ${
+              isHistoryRowActive(item.row.id)
+                ? SIDEBAR_SUBMENU_ICON_ACTIVE_CLASS
+                : `${item.tintClass} ${SIDEBAR_SUBMENU_ICON_INACTIVE_CLASS}`
+            }`}
+          >
+            <CalendarDays size={16} />
+          </span>
+          <span className="min-w-0 flex-1">
+            {showPendingBadge ? (
+              <span className="flex items-center gap-2">
+                <span
+                  className={`font-[var(--font-josefin-sans)] block truncate text-[0.98rem] font-bold leading-none md:text-[1.02rem] ${
+                    isHistoryRowActive(item.row.id)
+                      ? SIDEBAR_SUBMENU_LABEL_ACTIVE_CLASS
+                      : SIDEBAR_SUBMENU_LABEL_INACTIVE_CLASS
+                  }`}
+                >
+                  {item.title}
+                </span>
+                {item.shareStatus === "pending" ? (
+                  <span className="shrink-0 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.08em] text-amber-700">
+                    Pending
+                  </span>
+                ) : null}
+              </span>
+            ) : (
               <span
                 className={`font-[var(--font-josefin-sans)] block truncate text-[0.98rem] font-bold leading-none md:text-[1.02rem] ${
                   isHistoryRowActive(item.row.id)
@@ -763,34 +788,49 @@ function EventListPanel({
               >
                 {item.title}
               </span>
-              {item.shareStatus === "pending" ? (
-                <span className="shrink-0 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.08em] text-amber-700">
-                  Pending
-                </span>
-              ) : null}
-            </span>
-          ) : (
+            )}
             <span
-              className={`font-[var(--font-josefin-sans)] block truncate text-[0.98rem] font-bold leading-none md:text-[1.02rem] ${
+              className={`mt-0.5 block truncate text-xs ${
                 isHistoryRowActive(item.row.id)
-                  ? SIDEBAR_SUBMENU_LABEL_ACTIVE_CLASS
-                  : SIDEBAR_SUBMENU_LABEL_INACTIVE_CLASS
+                  ? "text-[#9d95db]"
+                  : "text-[#c1bcf0] group-hover:text-[#b0aae4]"
               }`}
             >
-              {item.title}
+              {item.dateLabel}
             </span>
-          )}
-          <span
-            className={`mt-0.5 block truncate text-xs ${
-              isHistoryRowActive(item.row.id)
-                ? "text-[#9d95db]"
-                : "text-[#c1bcf0] group-hover:text-[#b0aae4]"
-            }`}
-          >
-            {item.dateLabel}
           </span>
-        </span>
-      </button>
+        </button>
+        {item.showQuickActions ? (
+          <span className="ml-2 flex shrink-0 items-center gap-1">
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                void onShareRow(item);
+              }}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[#e5e0ff] bg-white/85 text-[#7a6fd1] transition hover:bg-white"
+              aria-label={`Share ${item.title}`}
+              title="Share event"
+            >
+              <Share2 size={13} />
+            </button>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                void onDeleteRow(item);
+              }}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[#ffe1ea] bg-white/85 text-[#d2618e] transition hover:bg-white"
+              aria-label={`Delete ${item.title}`}
+              title="Delete event"
+            >
+              <Trash2 size={13} />
+            </button>
+          </span>
+        ) : null}
+      </div>
     ));
 
   const renderGroupSections = (
@@ -1281,6 +1321,8 @@ export default function LeftSidebar() {
                       emptyPastCopy="No past events."
                       isHistoryRowActive={viewModel.isHistoryRowActive}
                       onRowClick={viewModel.openOwnerEventContext}
+                      onShareRow={viewModel.shareEventFromList}
+                      onDeleteRow={viewModel.deleteEventFromList}
                       pastExpanded={viewModel.showPastMyEvents}
                       setPastExpanded={viewModel.setShowPastMyEvents}
                       showPendingBadge={false}
@@ -1304,6 +1346,8 @@ export default function LeftSidebar() {
                       emptyPastCopy="No past invited events."
                       isHistoryRowActive={viewModel.isHistoryRowActive}
                       onRowClick={viewModel.openGuestEventContext}
+                      onShareRow={viewModel.shareEventFromList}
+                      onDeleteRow={viewModel.deleteEventFromList}
                       pastExpanded={viewModel.showPastInvitedEvents}
                       setPastExpanded={viewModel.setShowPastInvitedEvents}
                       showPendingBadge


### PR DESCRIPTION
### Motivation
- Provide quick per-row actions in the sidebar to let users share or delete events that came from invitations or were ingested via snap/scan/upload flows. 

### Description
- Add `showQuickActions` to `GroupedEventItem` and set it for invited rows or rows inferred as snapped/uploaded by inspecting `data.invitedFromScan` and `createdVia|source|ingestMethod|origin` in `buildGroupedEventLists` (`src/app/left-sidebar.model.ts`).
- Add `shareEventFromList` and `deleteEventFromList` handlers to the left-sidebar controller that use the Web Share API / clipboard for sharing and `DELETE /api/history/:id` plus `history:deleted` dispatch for deletion and UI sync (`src/app/left-sidebar.controller.ts`).
- Render inline Share and Delete icon buttons in `EventListPanel` rows when `showQuickActions` is true, and wire the buttons to the new handlers while stopping event propagation so row navigation still works (`src/app/left-sidebar.tsx`).
- Use `Share2` and `Trash2` icons and conservative styles to match existing sidebar chrome; both My Events and Invited Events panels receive the new callbacks. 

### Testing
- Ran targeted linter on the changed files with `npx biome lint src/app/left-sidebar.tsx src/app/left-sidebar.controller.ts src/app/left-sidebar.model.ts` and it completed with no errors (one unrelated warning about an unused local variable was reported). 
- Executed the sidebar unit tests with `node --test src/app/left-sidebar.model.test.mjs src/app/left-sidebar.mobile-nav.test.mjs src/app/left-sidebar.create-access.test.mjs` and all tests passed. 
- Note: the top-level `npm run lint` checks the whole repo and still reports unrelated pre-existing diagnostics; the targeted lint and unit tests above validate the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb497876c832c8a1a2cd88b5fe353)