### PR TITLE
Only show scanned-invite fields when provided; surface mobile action controls

### DIFF
--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -1565,7 +1565,7 @@ export default async function EventPage({
       (typeof data?.goodToKnow === "string" && data.goodToKnow.trim()) ||
       (typeof data?.thingsToDo === "string" && data.thingsToDo.trim()) ||
       (typeof data?.description === "string" && data.description.trim()) ||
-      "Details, RSVP, and calendar links are ready to share.";
+      null;
     const scannedInviteActivities = Array.isArray((data as any)?.activities)
       ? ((data as any).activities as unknown[])
           .map((item) => (typeof item === "string" ? item.trim() : ""))

--- a/src/components/GraduationSkin.tsx
+++ b/src/components/GraduationSkin.tsx
@@ -65,10 +65,6 @@ export default function GraduationSkin({
     dominant: palette?.dominant || "#5b3cc4",
     themeColor: palette?.themeColor || "#5b3cc4",
   };
-  const graduationActivities =
-    Array.isArray(activities) && activities.length
-      ? activities
-      : ["Commencement", "Photo Moments", "Celebration Gathering"];
 
   return (
     <ScannedInviteSkin
@@ -84,12 +80,9 @@ export default function GraduationSkin({
       rsvpPhone={rsvpPhone}
       rsvpEmail={rsvpEmail}
       rsvpUrl={rsvpUrl}
-      detailCopy={
-        detailCopy ||
-        "Join us to honor the graduate, celebrate this milestone, and capture memories together."
-      }
-      activities={graduationActivities}
-      attire={attire || "Grad celebration attire"}
+      detailCopy={detailCopy}
+      activities={activities}
+      attire={attire}
       registryUrl={registryUrl}
       actions={actions}
     />

--- a/src/components/ScannedInviteSkin.tsx
+++ b/src/components/ScannedInviteSkin.tsx
@@ -123,8 +123,7 @@ export default function ScannedInviteSkin({
   const displayLocation = String(location || "").trim() || "Location TBD";
   const directionsHref = buildMapsHref(location);
   const directRsvpHref = buildRsvpHref({ rsvpUrl, rsvpPhone, rsvpEmail });
-  const displayDetailCopy =
-    String(detailCopy || "").trim() || "Details, RSVP, and calendar links are ready to share.";
+  const displayDetailCopy = String(detailCopy || "").trim();
   const displayAttire = String(attire || "").trim();
   const displayRegistryUrl = String(registryUrl || "").trim();
   const displayActivities = Array.isArray(activities)
@@ -176,7 +175,14 @@ export default function ScannedInviteSkin({
       }}
     >
       <div className="mx-auto max-w-6xl px-4 pb-8 pt-[calc(env(safe-area-inset-top)+5.75rem)] md:px-8 md:pt-8">
-        {actions ? <div className="mb-5 hidden justify-end md:flex">{actions}</div> : null}
+        {actions ? (
+          <>
+            <div className="fixed right-4 top-[calc(env(safe-area-inset-top)+6.75rem)] z-[35] md:hidden">
+              {actions}
+            </div>
+            <div className="mb-5 hidden justify-end md:flex">{actions}</div>
+          </>
+        ) : null}
 
         <div className="mb-12 flex max-w-6xl flex-col items-center justify-between gap-8 pt-4 text-center md:flex-row md:items-center md:pt-12 md:text-left">
           <div className="flex-1 space-y-4 text-center md:text-left">
@@ -313,29 +319,31 @@ export default function ScannedInviteSkin({
               disabled={!directRsvpHref || previewMode}
             />
 
-            <motion.section
-              initial={{ y: 20, opacity: 0 }}
-              animate={{ y: 0, opacity: 1 }}
-              transition={{ delay: 0.4 }}
-              className="col-span-2 flex items-center justify-between gap-6 rounded-[3rem] border border-black/5 p-7 shadow-sm backdrop-blur-sm md:p-10"
-              style={{
-                backgroundColor:
-                  mixHexColors(colors.background, "#ffffff", 0.12) || colors.background,
-              }}
-            >
-              <div className="space-y-1">
-                <div className="text-[10px] font-black uppercase tracking-widest text-black/30">
-                  Good to Know
-                </div>
-                <div className="text-2xl font-bold text-black/90">{displayDetailCopy}</div>
-              </div>
-              <div
-                className="flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-lg"
-                style={{ color: "var(--theme-secondary)" }}
+            {displayDetailCopy ? (
+              <motion.section
+                initial={{ y: 20, opacity: 0 }}
+                animate={{ y: 0, opacity: 1 }}
+                transition={{ delay: 0.4 }}
+                className="col-span-2 flex items-center justify-between gap-6 rounded-[3rem] border border-black/5 p-7 shadow-sm backdrop-blur-sm md:p-10"
+                style={{
+                  backgroundColor:
+                    mixHexColors(colors.background, "#ffffff", 0.12) || colors.background,
+                }}
               >
-                <Sparkles className="h-6 w-6" />
-              </div>
-            </motion.section>
+                <div className="space-y-1">
+                  <div className="text-[10px] font-black uppercase tracking-widest text-black/30">
+                    Good to Know
+                  </div>
+                  <div className="text-2xl font-bold text-black/90">{displayDetailCopy}</div>
+                </div>
+                <div
+                  className="flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-lg"
+                  style={{ color: "var(--theme-secondary)" }}
+                >
+                  <Sparkles className="h-6 w-6" />
+                </div>
+              </motion.section>
+            ) : null}
             {displayAttire ? (
               <motion.section
                 initial={{ y: 20, opacity: 0 }}


### PR DESCRIPTION
### Motivation
- Prevent the UI from synthesizing or showing default invitation details (dress code, event flow, and "Good to Know" copy) when those fields are absent from scanned/OCR data.
- Make event action controls (edit/delete/share) visible on mobile by showing them as a floating block under the top nav instead of being hidden behind the white top bar.

### Description
- Removed graduation-specific fallback content and defaults so `GraduationSkin` now passes `detailCopy`, `activities`, and `attire` through as-provided instead of injecting `"Grad celebration attire"` or canned activity items.
- Stopped supplying a generic fallback string for scanned-invite details in the event page mapping and made `scannedInviteDetailCopy` nullable so missing OCR fields remain empty.
- Changed `ScannedInviteSkin` to (1) treat `detailCopy` as optional (no default text) and only render the "Good to Know" section when actual detail text exists, and (2) render the `actions` node as a fixed floating control on small screens (`fixed right-4 top-[calc(...)] z-[35] md:hidden`) while preserving the desktop action bar.

### Testing
- Ran `node --test src/app/card/[id]/page.test.mjs`, which completed without failures (no active tests in that file).
- Ran `npm run lint -- src/components/ScannedInviteSkin.tsx src/components/GraduationSkin.tsx src/app/event/[id]/page.tsx`, which surfaced existing repo-wide Biome diagnostics and exited non-zero; the failures are pre-existing and unrelated to these targeted changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb7e224ec832c99eda251028cfb7c)