### PR TITLE
Hide inferred midnight time and suppress At row when no time present

### DIFF
--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -337,6 +337,21 @@ const collapseDuplicateRangeLabel = (label: string | null | undefined): string |
 
 const EXPLICIT_TIME_RANGE_REGEX =
   /\b\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)\s*(?:-|–|to)\s*\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)\b/i;
+const ISO_MIDNIGHT_REGEX =
+  /^\d{4}-\d{2}-\d{2}T00:00(?::00(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:?\d{2})?$/i;
+
+const hasMeaningfulTimeToken = (value: string | null | undefined): boolean => {
+  const trimmed = String(value || "").trim();
+  if (!trimmed) return false;
+  const tokens = extractTimeTokens(trimmed);
+  if (tokens.length === 0) return false;
+  const hasAmPmToken = tokens.some((token) => /[ap]\.?m\.?/i.test(token));
+  if (hasAmPmToken) return true;
+  if (ISO_MIDNIGHT_REGEX.test(trimmed) && tokens.every((token) => normalizeTimeToken(token) === 0)) {
+    return false;
+  }
+  return true;
+};
 
 const shouldHideInferredOcrEndTime = (
   payload: Record<string, unknown> | null | undefined,
@@ -423,16 +438,19 @@ function formatTimeAndDate(
     let time: string | null = null;
     let date: string | null = null;
 
+    const shouldDisplayTime =
+      hasMeaningfulTimeToken(startInput) || hasMeaningfulTimeToken(endInput);
+
     if (end) {
       if (sameDay) {
-        time = `${timeFmt.format(start)} – ${timeFmt.format(end)}`;
+        time = shouldDisplayTime ? `${timeFmt.format(start)} – ${timeFmt.format(end)}` : null;
         date = dateFmt.format(start);
       } else {
-        time = `${timeFmt.format(start)} – ${timeFmt.format(end)}`;
+        time = shouldDisplayTime ? `${timeFmt.format(start)} – ${timeFmt.format(end)}` : null;
         date = `${dateFmt.format(start)} – ${dateFmt.format(end)}`;
       }
     } else {
-      time = timeFmt.format(start);
+      time = shouldDisplayTime ? timeFmt.format(start) : null;
       date = dateFmt.format(start);
     }
 

--- a/src/components/BirthdaySkin.tsx
+++ b/src/components/BirthdaySkin.tsx
@@ -146,7 +146,8 @@ export default function BirthdaySkin({
 
   const displayName = extractHonoreeName(title, honoreeName);
   const displayDate = String(dateLabel || "").trim() || "Date TBD";
-  const displayTime = String(timeLabel || "").trim() || "Time TBD";
+  const displayTime = String(timeLabel || "").trim();
+  const hasDisplayTime = Boolean(displayTime);
   const displayLocation = String(location || "").trim() || "Location TBD";
   const directionsHref = buildMapsHref(location);
   const directRsvpHref = buildRsvpHref({ rsvpUrl, rsvpPhone, rsvpEmail, title, shareUrl });
@@ -299,12 +300,14 @@ export default function BirthdaySkin({
                 title={displayDate}
               />
 
-              <InfoBlock
-                icon={<Clock className="h-8 w-8" />}
-                swatchColor="var(--theme-secondary)"
-                label="At"
-                title={displayTime}
-              />
+              {hasDisplayTime ? (
+                <InfoBlock
+                  icon={<Clock className="h-8 w-8" />}
+                  swatchColor="var(--theme-secondary)"
+                  label="At"
+                  title={displayTime}
+                />
+              ) : null}
 
               <InfoBlock
                 icon={<MapPin className="h-8 w-8" />}

--- a/src/components/ScannedInviteSkin.tsx
+++ b/src/components/ScannedInviteSkin.tsx
@@ -155,7 +155,8 @@ export default function ScannedInviteSkin({
   const displayTitle = String(title || "").trim() || "Celebration";
   const displayCategoryLabel = formatCategoryLabel(categoryLabel);
   const displayDate = String(dateLabel || "").trim() || "Date TBD";
-  const displayTime = String(timeLabel || "").trim() || "Time TBD";
+  const displayTime = String(timeLabel || "").trim();
+  const hasDisplayTime = Boolean(displayTime);
   const displayLocation = String(location || "").trim() || "Location TBD";
   const directionsHref = buildMapsHref(location);
   const directRsvpHref = buildRsvpHref({
@@ -314,12 +315,14 @@ export default function ScannedInviteSkin({
                 title={displayDate}
               />
 
-              <InfoBlock
-                icon={<Clock className="h-8 w-8" />}
-                swatchColor="var(--theme-secondary)"
-                label="At"
-                title={displayTime}
-              />
+              {hasDisplayTime ? (
+                <InfoBlock
+                  icon={<Clock className="h-8 w-8" />}
+                  swatchColor="var(--theme-secondary)"
+                  label="At"
+                  title={displayTime}
+                />
+              ) : null}
 
               <InfoBlock
                 icon={<MapPin className="h-8 w-8" />}

--- a/src/components/event-skin-time-rows.source.test.mjs
+++ b/src/components/event-skin-time-rows.source.test.mjs
@@ -13,12 +13,12 @@ const runtimeSkinSources = [
   "src/components/weddings/ScannedWeddingInviteView.tsx",
 ];
 
-test("event skins render date and time as separate When and At rows", () => {
+test("event skins render date row and gate the At row on available time", () => {
   for (const relPath of runtimeSkinSources) {
     const source = readSource(relPath);
 
     assert.match(source, /label="When"[\s\S]*?title=\{displayDate\}/, relPath);
-    assert.match(source, /label="At"[\s\S]*?title=\{displayTime\}/, relPath);
+    assert.match(source, /hasDisplayTime\s*\?\s*\([\s\S]*label="At"[\s\S]*title=\{displayTime\}/, relPath);
     assert.doesNotMatch(source, /subtitle=\{displayTime\}/, relPath);
   }
 });

--- a/src/components/weddings/ScannedWeddingInviteView.tsx
+++ b/src/components/weddings/ScannedWeddingInviteView.tsx
@@ -122,7 +122,8 @@ export default function ScannedWeddingInviteView({
   const couple = useMemo(() => parseWeddingCoupleNames(title), [title]);
   const displayLocation = location?.trim() || "Location TBD";
   const displayDate = dateLabel?.trim() || "Date TBD";
-  const displayTime = timeLabel?.trim() || "Time TBD";
+  const displayTime = timeLabel?.trim() || "";
+  const hasDisplayTime = Boolean(displayTime);
   const hasRsvp = Boolean(rsvpName || rsvpPhone || rsvpEmail || rsvpUrl);
   const showRsvpSection = hasRsvp || (previewMode && showRsvpPreview);
   const hasRegistries = registryCards.length > 0;
@@ -307,13 +308,15 @@ export default function ScannedWeddingInviteView({
                   colors={colors}
                   darkMode={isNoirModern}
                 />
-                <DetailItem
-                  icon={<Clock className="h-5 w-5" />}
-                  label="At"
-                  title={displayTime}
-                  colors={colors}
-                  darkMode={isNoirModern}
-                />
+                {hasDisplayTime ? (
+                  <DetailItem
+                    icon={<Clock className="h-5 w-5" />}
+                    label="At"
+                    title={displayTime}
+                    colors={colors}
+                    darkMode={isNoirModern}
+                  />
+                ) : null}
               </div>
               <DetailItem
                 icon={<MapPin className="h-5 w-5" />}


### PR DESCRIPTION
### Motivation
- Date-only events stored as ISO midnight (T00:00) were rendered as an inferred `12:00 AM`, which is misleading for invites with no time. 
- Scanned/templated invite skins should not show an “At” row unless an explicit time is present in the parsed payload.

### Description
- Add `ISO_MIDNIGHT_REGEX` and `hasMeaningfulTimeToken` helpers and use them in `formatTimeAndDate` to suppress time output when only an inferred midnight exists (`src/app/event/[id]/page.tsx`).
- Gate time formatting on a `shouldDisplayTime` check so `formatTimeAndDate` returns `time: null` for date-only inputs (`src/app/event/[id]/page.tsx`).
- Stop defaulting missing time to a filler string and render the “At” block only when `timeLabel` exists in `BirthdaySkin`, `ScannedInviteSkin`, and `ScannedWeddingInviteView` (`src/components/BirthdaySkin.tsx`, `src/components/ScannedInviteSkin.tsx`, `src/components/weddings/ScannedWeddingInviteView.tsx`).
- Update the source-guard test to assert runtime skins gate the At row behind the new `hasDisplayTime` condition (`src/components/event-skin-time-rows.source.test.mjs`).

### Testing
- Ran the source guard: `node --test src/components/event-skin-time-rows.source.test.mjs`, which passed.
- Ran targeted lint on the changed files with `npx biome lint <files>`, which completed successfully for the touched files.
- Running the project-wide `npm run lint` surfaced many pre-existing diagnostics unrelated to these changes and did not block the targeted validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00fae1e44832c8d0e0504e074edd6)