### PR TITLE
Add BasketballSkin and auto-detect basketball scanned invites

### DIFF
--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -9,6 +9,7 @@ import type { CSSProperties, ReactNode } from "react";
 import { cache } from "react";
 import AccessCodeGate from "@/components/AccessCodeGate";
 import AppleCalendarLink from "@/components/AppleCalendarLink";
+import BasketballSkin from "@/components/BasketballSkin";
 import BirthdaySkin from "@/components/BirthdaySkin";
 import GraduationSkin from "@/components/GraduationSkin";
 import ScannedInviteSkin from "@/components/ScannedInviteSkin";
@@ -1711,6 +1712,18 @@ export default async function EventPage({
         ? ((data as any).attire as string).trim()
         : null;
     const scannedInviteRegistryUrl = registryLinks[0]?.url || null;
+    const basketballContextText = [
+      String(categoryRaw || ""),
+      String((data as any)?.category || ""),
+      String((data as any)?.title || ""),
+      String((data as any)?.description || ""),
+      ...scannedInviteActivities,
+    ]
+      .join(" ")
+      .toLowerCase();
+    const isBasketballInvite = /\bbasketball\b|\bopen run\b|\bpickup\b|\b3v3\b|\b5v5\b/.test(
+      basketballContextText,
+    );
     const scannedInviteActions =
       !isReadOnly &&
       isOwner && (
@@ -1755,6 +1768,32 @@ export default async function EventPage({
     if (categoryNormalized === "graduations") {
       return renderWithEventPageBackground(
         <GraduationSkin
+          title={title}
+          dateLabel={scannedInviteDateLabel || whenLabel || null}
+          timeLabel={formattedTimeAndDate.time || null}
+          location={locationText || venueText || null}
+          imageUrl={scannedInviteImageUrl}
+          shareUrl={shareUrl}
+          calendarLinks={calendarLinks}
+          skinId={ocrSkin?.skinId || null}
+          palette={ocrSkin?.palette || null}
+          background={ocrSkin?.background || null}
+          rsvpName={rsvpName}
+          rsvpPhone={rsvpPhone}
+          rsvpEmail={rsvpEmail}
+          rsvpUrl={rsvpUrl}
+          detailCopy={scannedInviteDetailCopy}
+          activities={scannedInviteActivities}
+          attire={scannedInviteAttire}
+          registryUrl={scannedInviteRegistryUrl}
+          actions={scannedInviteActions}
+        />,
+      );
+    }
+
+    if (isBasketballInvite) {
+      return renderWithEventPageBackground(
+        <BasketballSkin
           title={title}
           dateLabel={scannedInviteDateLabel || whenLabel || null}
           timeLabel={formattedTimeAndDate.time || null}

--- a/src/components/BasketballSkin.tsx
+++ b/src/components/BasketballSkin.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type { ReactNode } from "react";
+import ScannedInviteSkin from "@/components/ScannedInviteSkin";
+import type { OcrSkinBackground } from "@/lib/ocr/skin-background";
+
+type CalendarLinks = {
+  google: string;
+  outlook: string;
+  appleInline: string;
+};
+
+type Palette = {
+  background?: string;
+  primary?: string;
+  secondary?: string;
+  accent?: string;
+  text?: string;
+  dominant?: string;
+  themeColor?: string;
+} | null;
+
+type Props = {
+  title: string;
+  dateLabel?: string | null;
+  timeLabel?: string | null;
+  location?: string | null;
+  imageUrl?: string | null;
+  shareUrl?: string | null;
+  calendarLinks?: CalendarLinks | null;
+  skinId?: string | null;
+  palette?: Palette;
+  background?: OcrSkinBackground | null;
+  rsvpName?: string | null;
+  rsvpPhone?: string | null;
+  rsvpEmail?: string | null;
+  rsvpUrl?: string | null;
+  detailCopy?: string | null;
+  activities?: string[] | null;
+  attire?: string | null;
+  registryUrl?: string | null;
+  actions?: ReactNode;
+};
+
+const BASKETBALL_ACTIVITY_DEFAULTS = [
+  "Games: 5v5 full-court runs",
+  "Pickup: 3v3 half-court games",
+  "Training: dribbling and passing stations",
+  "Training: shooting reps and free throws",
+  "Training: finishing and footwork circuits",
+];
+
+export default function BasketballSkin({
+  title,
+  dateLabel,
+  timeLabel,
+  location,
+  imageUrl,
+  shareUrl,
+  calendarLinks,
+  skinId,
+  palette,
+  background,
+  rsvpName,
+  rsvpPhone,
+  rsvpEmail,
+  rsvpUrl,
+  detailCopy,
+  activities,
+  attire,
+  registryUrl,
+  actions,
+}: Props) {
+  const basketballPalette = {
+    background: palette?.background || "#fff6eb",
+    primary: palette?.primary || "#f97316",
+    secondary: palette?.secondary || "#111827",
+    accent: palette?.accent || "#f59e0b",
+    text: palette?.text || "#111827",
+    dominant: palette?.dominant || "#f97316",
+    themeColor: palette?.themeColor || "#f97316",
+  };
+
+  const displayActivities = Array.isArray(activities)
+    ? activities
+        .map((item) => String(item || "").trim())
+        .filter(Boolean)
+        .slice(0, 6)
+    : [];
+
+  return (
+    <ScannedInviteSkin
+      title={title}
+      categoryLabel="🏀 Basketball Run"
+      backgroundCategory="basketball"
+      dateLabel={dateLabel}
+      timeLabel={timeLabel}
+      location={location}
+      imageUrl={imageUrl}
+      shareUrl={shareUrl}
+      calendarLinks={calendarLinks}
+      skinId={skinId}
+      palette={basketballPalette}
+      background={background}
+      rsvpName={rsvpName}
+      rsvpPhone={rsvpPhone}
+      rsvpEmail={rsvpEmail}
+      rsvpUrl={rsvpUrl}
+      detailCopy={detailCopy || "Games, pickup, and training sessions for all levels."}
+      activities={displayActivities.length ? displayActivities : BASKETBALL_ACTIVITY_DEFAULTS}
+      attire={attire || "Basketball attire + indoor/outdoor shoes"}
+      registryUrl={registryUrl}
+      actions={actions}
+    />
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a specialized visual skin for basketball/open-run style scanned invites so these events render with appropriate branding and copy.
- Automatically detect basketball-related invites from OCR/scanned content to improve presentation without manual selection.

### Description
- Added a new `BasketballSkin` React component that wraps `ScannedInviteSkin` with basketball-themed palette, default activities, and copy.
- Imported `BasketballSkin` into the event page and added detection logic that builds a context string from `category`, `title`, `description`, and `activities`, then matches basketball-related keywords via regex to set `isBasketballInvite`.
- When a scanned invite is identified as basketball-related, the page now renders `BasketballSkin` instead of the generic `ScannedInviteSkin` and preserves RSVP, calendar, image, and actions props.
- Set sensible palette defaults and limited displayed activities to a small list with basketball-specific fallbacks.

### Testing
- Ran TypeScript type checking with `tsc --noEmit` and it completed without errors.
- Built the Next.js application with `next build` to validate server and client bundles and the build succeeded.
- Executed the existing test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f010a0c660832c8e0176dcfa143c58)