### PR TITLE
Prefer venue name in scanned skins and hide RSVP contact details

### DIFF
--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -1820,6 +1820,7 @@ export default async function EventPage({
       <ScannedWeddingInviteView
         eventId={row.id}
         title={title}
+        venueName={venueText || null}
         location={locationText || venueText || null}
         dateLabel={scannedInviteDateLabel || whenLabel || null}
         timeLabel={formattedTimeAndDate.time || null}
@@ -1911,6 +1912,7 @@ export default async function EventPage({
         title={title}
         dateLabel={scannedInviteDateLabel || whenLabel || null}
         timeLabel={formattedTimeAndDate.time || null}
+        venueName={venueText || null}
         location={locationText || venueText || null}
         imageUrl={scannedInviteImageUrl}
         shareUrl={shareUrl}
@@ -2000,6 +2002,7 @@ export default async function EventPage({
         title={title}
         dateLabel={scannedInviteDateLabel || whenLabel || null}
         timeLabel={formattedTimeAndDate.time || null}
+        venueName={venueText || null}
         location={locationText || venueText || null}
         imageUrl={scannedInviteImageUrl}
         shareUrl={shareUrl}
@@ -2089,6 +2092,7 @@ export default async function EventPage({
         title={title}
         dateLabel={scannedInviteDateLabel || whenLabel || null}
         timeLabel={formattedTimeAndDate.time || null}
+        venueName={venueText || null}
         location={locationText || venueText || null}
         imageUrl={scannedInviteImageUrl}
         shareUrl={shareUrl}
@@ -2191,6 +2195,7 @@ export default async function EventPage({
           title={title}
           dateLabel={scannedInviteDateLabel || whenLabel || null}
           timeLabel={formattedTimeAndDate.time || null}
+          venueName={venueText || null}
           location={locationText || venueText || null}
           imageUrl={scannedInviteImageUrl}
           shareUrl={shareUrl}
@@ -2218,6 +2223,7 @@ export default async function EventPage({
           title={title}
           dateLabel={scannedInviteDateLabel || whenLabel || null}
           timeLabel={formattedTimeAndDate.time || null}
+          venueName={venueText || null}
           location={locationText || venueText || null}
           imageUrl={scannedInviteImageUrl}
           shareUrl={shareUrl}
@@ -2246,6 +2252,7 @@ export default async function EventPage({
         categoryLabel={categoryRaw || "General Event"}
         dateLabel={scannedInviteDateLabel || whenLabel || null}
         timeLabel={formattedTimeAndDate.time || null}
+        venueName={venueText || null}
         location={locationText || venueText || null}
         imageUrl={scannedInviteImageUrl}
         shareUrl={shareUrl}

--- a/src/components/BasketballSkin.tsx
+++ b/src/components/BasketballSkin.tsx
@@ -25,6 +25,7 @@ type Props = {
   title: string;
   dateLabel?: string | null;
   timeLabel?: string | null;
+  venueName?: string | null;
   location?: string | null;
   imageUrl?: string | null;
   shareUrl?: string | null;
@@ -101,6 +102,7 @@ export default function BasketballSkin({
   title,
   dateLabel,
   timeLabel,
+  venueName,
   location,
   imageUrl,
   shareUrl,
@@ -146,6 +148,7 @@ export default function BasketballSkin({
       backgroundCategory="basketball"
       dateLabel={dateLabel}
       timeLabel={timeLabel}
+      venueName={venueName}
       location={location}
       imageUrl={imageUrl}
       shareUrl={shareUrl}

--- a/src/components/FootballSkin.tsx
+++ b/src/components/FootballSkin.tsx
@@ -25,6 +25,7 @@ type Props = {
   title: string;
   dateLabel?: string | null;
   timeLabel?: string | null;
+  venueName?: string | null;
   location?: string | null;
   imageUrl?: string | null;
   shareUrl?: string | null;
@@ -49,6 +50,7 @@ export default function FootballSkin({
   title,
   dateLabel,
   timeLabel,
+  venueName,
   location,
   imageUrl,
   shareUrl,
@@ -92,6 +94,7 @@ export default function FootballSkin({
       backgroundCategory="football"
       dateLabel={dateLabel}
       timeLabel={timeLabel}
+      venueName={venueName}
       location={location}
       imageUrl={imageUrl}
       shareUrl={shareUrl}

--- a/src/components/GraduationSkin.tsx
+++ b/src/components/GraduationSkin.tsx
@@ -25,6 +25,7 @@ type Props = {
   title: string;
   dateLabel?: string | null;
   timeLabel?: string | null;
+  venueName?: string | null;
   location?: string | null;
   imageUrl?: string | null;
   shareUrl?: string | null;
@@ -48,6 +49,7 @@ export default function GraduationSkin({
   title,
   dateLabel,
   timeLabel,
+  venueName,
   location,
   imageUrl,
   shareUrl,
@@ -83,6 +85,7 @@ export default function GraduationSkin({
       backgroundCategory="graduation"
       dateLabel={dateLabel}
       timeLabel={timeLabel}
+      venueName={venueName}
       location={location}
       imageUrl={imageUrl}
       shareUrl={shareUrl}

--- a/src/components/PickleballSkin.tsx
+++ b/src/components/PickleballSkin.tsx
@@ -25,6 +25,7 @@ type Props = {
   title: string;
   dateLabel?: string | null;
   timeLabel?: string | null;
+  venueName?: string | null;
   location?: string | null;
   imageUrl?: string | null;
   shareUrl?: string | null;
@@ -49,6 +50,7 @@ export default function PickleballSkin({
   title,
   dateLabel,
   timeLabel,
+  venueName,
   location,
   imageUrl,
   shareUrl,
@@ -93,6 +95,7 @@ export default function PickleballSkin({
       sportKind="pickleball"
       dateLabel={dateLabel}
       timeLabel={timeLabel}
+      venueName={venueName}
       location={location}
       imageUrl={imageUrl}
       shareUrl={shareUrl}

--- a/src/components/ScannedInviteSkin.tsx
+++ b/src/components/ScannedInviteSkin.tsx
@@ -51,6 +51,7 @@ type Props = {
   backgroundCategory?: string | null;
   dateLabel?: string | null;
   timeLabel?: string | null;
+  venueName?: string | null;
   location?: string | null;
   imageUrl?: string | null;
   shareUrl?: string | null;
@@ -184,6 +185,7 @@ export default function ScannedInviteSkin({
   backgroundCategory,
   dateLabel,
   timeLabel,
+  venueName,
   location,
   imageUrl,
   shareUrl,
@@ -249,6 +251,7 @@ export default function ScannedInviteSkin({
   const displayCategoryLabel = formatCategoryLabel(categoryLabel);
   const displayDate = String(dateLabel || "").trim() || "Date TBD";
   const displayTime = String(timeLabel || "").trim();
+  const displayVenueName = String(venueName || "").trim();
   const displayLocation = String(location || "").trim() || "Location TBD";
   const rawDetailCopy = String(detailCopy || "").trim();
   const isPickleballSkin = String(sportKind || "").toLowerCase() === "pickleball";
@@ -279,12 +282,9 @@ export default function ScannedInviteSkin({
         ? splitTimeRange[1]
         : "";
   const displayRsvpName = String(rsvpName || "").trim();
-  const displayRsvpTitle = displayRsvpName
-    ? /^hosted\s+by\b/i.test(displayRsvpName)
-      ? displayRsvpName
-      : `Hosted by ${displayRsvpName}`
-    : String(rsvpEmail || "Host");
-  const directionsHref = buildMapsHref(location);
+  const displayRsvpTitle = displayRsvpName.replace(/^hosted\s+by\s+/i, "").trim() || "Host";
+  const directionsLocation = [displayVenueName, displayLocation].filter(Boolean).join(", ");
+  const directionsHref = buildMapsHref(directionsLocation || location);
   const directRsvpHref = buildRsvpHref({
     rsvpUrl,
     rsvpPhone,
@@ -506,8 +506,8 @@ export default function ScannedInviteSkin({
                   icon={<MapPin className="h-7 w-7" />}
                   swatchColor={detailIconSwatchColor}
                   label="Where"
-                  title="Event Location"
-                  subtitle={displayLocation}
+                  title={displayVenueName || "Event Location"}
+                  subtitle={displayVenueName ? undefined : displayLocation}
                 />
 
                 {rsvpName || rsvpPhone || rsvpEmail ? (
@@ -516,10 +516,6 @@ export default function ScannedInviteSkin({
                     swatchColor={detailIconSwatchColor}
                     label="RSVP"
                     title={displayRsvpTitle}
-                    subtitle={
-                      String(rsvpEmail || rsvpPhone || "").trim() ||
-                      "Contact details available on request"
-                    }
                     divider
                   />
                 ) : null}

--- a/src/components/weddings/ScannedWeddingInviteView.tsx
+++ b/src/components/weddings/ScannedWeddingInviteView.tsx
@@ -60,6 +60,7 @@ type WeddingScanSkinId =
 type Props = {
   eventId?: string | null;
   title: string;
+  venueName?: string | null;
   location: string | null;
   dateLabel: string | null;
   timeLabel: string | null;
@@ -87,6 +88,7 @@ type Props = {
 export default function ScannedWeddingInviteView({
   eventId,
   title,
+  venueName,
   location,
   dateLabel,
   timeLabel,
@@ -124,10 +126,12 @@ export default function ScannedWeddingInviteView({
   const isNoirModern = resolvedSkinId === "scanned-wedding-noir-modern";
   const isGildedRomance = resolvedSkinId === "scanned-wedding-gilded-romance";
   const couple = useMemo(() => parseWeddingCoupleNames(title), [title]);
+  const displayVenueName = venueName?.trim() || "";
   const displayLocation = location?.trim() || "Location TBD";
+  const directionsLocation = [displayVenueName, displayLocation].filter(Boolean).join(", ");
   const displayDate = dateLabel?.trim() || "Date TBD";
   const displayTime = timeLabel?.trim() || "";
-  const hasRsvp = Boolean(rsvpName || rsvpPhone || rsvpEmail || rsvpUrl);
+  const hasRsvp = Boolean(rsvpName || rsvpUrl);
   const showRsvpSection = hasRsvp || (previewMode && showRsvpPreview);
   const hasRegistries = registryCards.length > 0;
   const timelineRows = scheduleRows.length > 0 ? scheduleRows : [];
@@ -206,9 +210,9 @@ export default function ScannedWeddingInviteView({
 
   const handleConcierge = () => {
     if (previewMode) return;
-    if (!displayLocation || displayLocation === "Location TBD") return;
+    if (!directionsLocation || directionsLocation === "Location TBD") return;
     window.open(
-      `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(displayLocation)}`,
+      `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(directionsLocation)}`,
       "_blank",
       "noopener,noreferrer",
     );
@@ -334,8 +338,8 @@ export default function ScannedWeddingInviteView({
               <DetailItem
                 icon={<MapPin className="h-5 w-5" />}
                 label="Where"
-                title="The Venue"
-                subtitle={displayLocation}
+                title={displayVenueName || "The Venue"}
+                subtitle={displayVenueName ? undefined : displayLocation}
                 colors={colors}
                 darkMode={isNoirModern}
               />
@@ -393,8 +397,7 @@ export default function ScannedWeddingInviteView({
                     className="max-w-md text-[0.98rem] font-light leading-relaxed"
                     style={{ color: mutedTextColor }}
                   >
-                    Reply directly from the event page using the saved RSVP contact found on the
-                    invitation.
+                    Reply directly from the event page.
                   </div>
                   {rsvpDeadline?.trim() ? (
                     <div
@@ -420,8 +423,8 @@ export default function ScannedWeddingInviteView({
                     <EventRsvpPrompt
                       eventId={eventId}
                       rsvpName={rsvpName}
-                      rsvpPhone={rsvpPhone}
-                      rsvpEmail={rsvpEmail}
+                      rsvpPhone={null}
+                      rsvpEmail={null}
                       rsvpUrl={rsvpUrl}
                       eventTitle={title}
                       eventCategory="Wedding"


### PR DESCRIPTION
### Motivation
- Scanned invite renderers should show the explicit venue name when available rather than only an address, to match design intent and reduce ambiguity. 
- Host contact information (phone/email) should not be published in the Where/RSVP info block by default to avoid exposing private contact details. 
- Apply the same venue-first and contact-hiding behavior consistently across scanned skins (birthday/general scanned, wedding, basketball, football, pickleball, graduation).

### Description
- Added a `venueName` prop to the shared scanned renderer and to skin wrappers so components can receive and prefer a dedicated venue label (`src/components/ScannedInviteSkin.tsx`, `src/components/*Skin.tsx`).
- Wired the scanned event page to pass both `venueName` and the full `location` into scanned wedding, pickleball, football, basketball, graduation, and generic scanned skins (`src/app/event/[id]/page.tsx`).
- Updated `ScannedInviteSkin` to prefer `venueName` for the Where/spot title, fall back to the full address when needed, build map directions from `venueName + location`, and render only the host/display name (fallback `Host`) without exposing phone/email in the info block (`src/components/ScannedInviteSkin.tsx`).
- Updated `ScannedWeddingInviteView` to follow the same venue-first display, use the combined venue+address for concierge/map lookups, and avoid passing phone/email into the wedding RSVP prompt surface (`src/components/weddings/ScannedWeddingInviteView.tsx`).
- Extended basketball/football/pickleball/graduation wrappers to accept and forward `venueName` to the shared scanned renderer (`src/components/BasketballSkin.tsx`, `src/components/FootballSkin.tsx`, `src/components/PickleballSkin.tsx`, `src/components/GraduationSkin.tsx`).

### Testing
- Ran the targeted component tests with `node --test src/components/BasketballSkin.source.test.mjs src/components/FootballSkin.source.test.mjs src/components/PickleballSkin.source.test.mjs` and all tests passed. 
- Ran the lint command `npm run lint -- <touched files>` which surfaced existing repository-wide Biome diagnostics (pre-existing issues); the lint invocation did not block the change but reported many unrelated warnings/errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a63491cc832cad66eb8c1a0ecd7e)