### PR TITLE
Restore Google sign-in in mobile hero menu login

### DIFF
--- a/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
+++ b/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
@@ -30,7 +30,6 @@ test("HeroTopNav keeps desktop auth actions while using inline login inside the 
   assert.match(source, /<LoginForm\s+variant="inline"/);
   assert.match(source, /onInlineCancel=\{\(\) => setMobileLoginExpanded\(false\)\}/);
   assert.match(source, /inlineTone=\{isDarkGlass \? "dark" : "light"\}/);
-  assert.match(source, /showGoogleAuth=\{false\}/);
   assert.match(source, /successRedirectUrl=\{loginSuccessRedirectUrl\}/);
   assert.match(
     source,

--- a/src/components/navigation/HeroTopNav.tsx
+++ b/src/components/navigation/HeroTopNav.tsx
@@ -377,7 +377,6 @@ export default function HeroTopNav({
                         <LoginForm
                           variant="inline"
                           inlineTone={isDarkGlass ? "dark" : "light"}
-                          showGoogleAuth={false}
                           successRedirectUrl={loginSuccessRedirectUrl}
                           onInlineCancel={() => setMobileLoginExpanded(false)}
                           onSwitchMode={() => {


### PR DESCRIPTION
### Motivation
- Mobile users reported the hero dropdown login no longer showed the "Sign in with Google" option, so the inline `LoginForm` in the mobile menu should expose Google auth again.

### Description
- Removed the `showGoogleAuth={false}` override on the inline `LoginForm` used by the mobile hero menu so the Google button is rendered again (`src/components/navigation/HeroTopNav.tsx`).
- Updated the source-shape regression test to stop asserting that Google auth is hidden in the mobile inline login (`src/components/navigation/HeroTopNav.mobile-login.source.test.mjs`).

### Testing
- Ran `node --test src/components/navigation/HeroTopNav.mobile-login.source.test.mjs`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0af5fa610832c95996ebce3ca868f)