### PR TITLE
Add BabyShower and GenericEvent skins and route scanned/OCR events accordingly

### DIFF
--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -9,6 +9,7 @@ import type { CSSProperties, ReactNode } from "react";
 import { cache } from "react";
 import AccessCodeGate from "@/components/AccessCodeGate";
 import AppleCalendarLink from "@/components/AppleCalendarLink";
+import BabyShowerSkin from "@/components/BabyShowerSkin";
 import BasketballSkin from "@/components/BasketballSkin";
 import BirthdaySkin from "@/components/BirthdaySkin";
 import { BIRTHDAY_THEMES } from "@/components/birthdays/birthdayThemes";
@@ -23,12 +24,12 @@ import EventMap from "@/components/EventMap";
 import EventRsvpDashboard from "@/components/EventRsvpDashboard";
 import EventRsvpPrompt from "@/components/EventRsvpPrompt";
 import FootballSkin from "@/components/FootballSkin";
+import GenericEventSkin from "@/components/GenericEventSkin";
 import GraduationSkin from "@/components/GraduationSkin";
 import { isGymMeetTemplateId } from "@/components/gym-meet-templates/registry";
 import LocationLink from "@/components/LocationLink";
 import OpenHouseSkin from "@/components/OpenHouseSkin";
 import PickleballSkin from "@/components/PickleballSkin";
-import ScannedInviteSkin from "@/components/ScannedInviteSkin";
 import SponsoredSupplies from "@/components/SponsoredSupplies";
 import ThumbnailModal from "@/components/ThumbnailModal";
 import { absoluteUrl, sanitizePersistedMediaUrl } from "@/lib/absolute-url";
@@ -1661,7 +1662,6 @@ export default async function EventPage({
   const isGenericScannedInviteEvent =
     categoryNormalized !== "birthdays" &&
     categoryNormalized !== "weddings" &&
-    isScannedInviteEvent &&
     isOcrEvent &&
     isOcrInviteCategory(categoryRaw);
   const isDiscoverySimpleTemplate = isGymnasticsDiscoveryTemplate || isFootballDiscoveryTemplate;
@@ -2368,6 +2368,34 @@ export default async function EventPage({
       </div>
     );
 
+    if (categoryNormalized === "baby showers" || categoryNormalized === "baby shower") {
+      return renderWithEventPageBackground(
+        <BabyShowerSkin
+          title={title}
+          dateLabel={scannedInviteDateLabel || whenLabel || null}
+          timeLabel={formattedTimeAndDate.time || null}
+          venueName={venueText || null}
+          location={locationText || venueText || null}
+          imageUrl={scannedInviteImageUrl}
+          shareUrl={shareUrl}
+          calendarLinks={calendarLinks}
+          skinId={ocrSkin?.skinId || null}
+          palette={ocrSkin?.palette || null}
+          background={ocrSkin?.background || null}
+          rsvpName={rsvpName}
+          rsvpPhone={rsvpPhone}
+          rsvpEmail={rsvpEmail}
+          rsvpUrl={rsvpUrl}
+          detailCopy={scannedInviteDetailCopy}
+          activities={scannedInviteActivities}
+          attire={scannedInviteAttire}
+          registryUrl={scannedInviteRegistryUrl}
+          ocrFacts={scannedInviteOcrFacts}
+          actions={scannedInviteActions}
+        />,
+      );
+    }
+
     if (categoryNormalized === "graduations") {
       return renderWithEventPageBackground(
         <GraduationSkin
@@ -2426,7 +2454,7 @@ export default async function EventPage({
     }
 
     return renderWithEventPageBackground(
-      <ScannedInviteSkin
+      <GenericEventSkin
         title={title}
         categoryLabel={categoryRaw || "General Event"}
         dateLabel={scannedInviteDateLabel || whenLabel || null}
@@ -2449,6 +2477,50 @@ export default async function EventPage({
         registryUrl={scannedInviteRegistryUrl}
         ocrFacts={scannedInviteOcrFacts}
         actions={scannedInviteActions}
+      />,
+    );
+  }
+
+  if (isOcrEvent) {
+    const ocrSkin = normalizeOcrSkinSelection((data as any)?.ocrSkin, categoryRaw, undefined, {
+      title,
+    });
+    return renderWithEventPageBackground(
+      <GenericEventSkin
+        title={title}
+        categoryLabel={categoryRaw || "General Event"}
+        dateLabel={scannedInviteDateLabel || whenLabel || null}
+        timeLabel={formattedTimeAndDate.time || null}
+        venueName={venueText || null}
+        location={locationText || venueText || null}
+        imageUrl={headerImageUrl}
+        shareUrl={shareUrl}
+        calendarLinks={calendarLinks}
+        skinId={ocrSkin?.skinId || null}
+        palette={ocrSkin?.palette || null}
+        background={ocrSkin?.background || null}
+        rsvpName={rsvpName}
+        rsvpPhone={rsvpPhone}
+        rsvpEmail={rsvpEmail}
+        rsvpUrl={rsvpUrl}
+        detailCopy={
+          (typeof data?.goodToKnow === "string" && data.goodToKnow.trim()) ||
+          (typeof data?.thingsToDo === "string" && data.thingsToDo.trim()) ||
+          (typeof data?.description === "string" && data.description.trim()) ||
+          null
+        }
+        activities={Array.isArray((data as any)?.activities)
+          ? ((data as any).activities as unknown[])
+              .map((item) => (typeof item === "string" ? item.trim() : ""))
+              .filter(Boolean)
+          : []}
+        attire={
+          typeof (data as any)?.attire === "string" && (data as any).attire.trim()
+            ? ((data as any).attire as string).trim()
+            : null
+        }
+        registryUrl={registryLinks[0]?.url || null}
+        ocrFacts={scannedInviteOcrFacts}
       />,
     );
   }

--- a/src/components/BabyShowerSkin.tsx
+++ b/src/components/BabyShowerSkin.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import type { ReactNode } from "react";
+import ScannedInviteSkin from "@/components/ScannedInviteSkin";
+import type { OcrFact } from "@/lib/ocr/facts";
+import type { OcrSkinBackground } from "@/lib/ocr/skin-background";
+
+type CalendarLinks = {
+  google: string;
+  outlook: string;
+  appleInline: string;
+};
+
+type Palette = {
+  background?: string;
+  primary?: string;
+  secondary?: string;
+  accent?: string;
+  text?: string;
+  dominant?: string;
+  themeColor?: string;
+} | null;
+
+type Props = {
+  title: string;
+  dateLabel?: string | null;
+  timeLabel?: string | null;
+  venueName?: string | null;
+  location?: string | null;
+  imageUrl?: string | null;
+  shareUrl?: string | null;
+  calendarLinks?: CalendarLinks | null;
+  skinId?: string | null;
+  palette?: Palette;
+  background?: OcrSkinBackground | null;
+  rsvpName?: string | null;
+  rsvpPhone?: string | null;
+  rsvpEmail?: string | null;
+  rsvpUrl?: string | null;
+  detailCopy?: string | null;
+  activities?: string[] | null;
+  attire?: string | null;
+  registryUrl?: string | null;
+  ocrFacts?: OcrFact[] | null;
+  actions?: ReactNode;
+};
+
+export default function BabyShowerSkin({
+  title,
+  dateLabel,
+  timeLabel,
+  venueName,
+  location,
+  imageUrl,
+  shareUrl,
+  calendarLinks,
+  skinId,
+  palette,
+  background,
+  rsvpName,
+  rsvpPhone,
+  rsvpEmail,
+  rsvpUrl,
+  detailCopy,
+  activities,
+  attire,
+  registryUrl,
+  ocrFacts,
+  actions,
+}: Props) {
+  const babyShowerPalette = {
+    background: palette?.background || "#fdf7ff",
+    primary: palette?.primary || "#8f63d8",
+    secondary: palette?.secondary || "#b08ce8",
+    accent: palette?.accent || "#f3b8d0",
+    text: palette?.text || "#2f1f45",
+    dominant: palette?.dominant || "#8f63d8",
+    themeColor: palette?.themeColor || "#8f63d8",
+  };
+
+  return (
+    <ScannedInviteSkin
+      title={title}
+      categoryLabel="🍼 Baby Shower"
+      backgroundCategory="baby shower"
+      dateLabel={dateLabel}
+      timeLabel={timeLabel}
+      venueName={venueName}
+      location={location}
+      imageUrl={imageUrl}
+      shareUrl={shareUrl}
+      calendarLinks={calendarLinks}
+      skinId={skinId}
+      palette={babyShowerPalette}
+      background={background}
+      rsvpName={rsvpName}
+      rsvpPhone={rsvpPhone}
+      rsvpEmail={rsvpEmail}
+      rsvpUrl={rsvpUrl}
+      detailCopy={detailCopy}
+      activities={activities}
+      attire={attire}
+      registryUrl={registryUrl}
+      ocrFacts={ocrFacts}
+      detailLayout="wideDetails"
+      actions={actions}
+    />
+  );
+}

--- a/src/components/GenericEventSkin.tsx
+++ b/src/components/GenericEventSkin.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { ReactNode } from "react";
+import ScannedInviteSkin from "@/components/ScannedInviteSkin";
+import type { OcrFact } from "@/lib/ocr/facts";
+import type { OcrSkinBackground } from "@/lib/ocr/skin-background";
+
+type CalendarLinks = {
+  google: string;
+  outlook: string;
+  appleInline: string;
+};
+
+type Palette = {
+  background?: string;
+  primary?: string;
+  secondary?: string;
+  accent?: string;
+  text?: string;
+  dominant?: string;
+  themeColor?: string;
+} | null;
+
+type Props = {
+  title: string;
+  categoryLabel?: string | null;
+  dateLabel?: string | null;
+  timeLabel?: string | null;
+  venueName?: string | null;
+  location?: string | null;
+  imageUrl?: string | null;
+  shareUrl?: string | null;
+  calendarLinks?: CalendarLinks | null;
+  skinId?: string | null;
+  palette?: Palette;
+  background?: OcrSkinBackground | null;
+  rsvpName?: string | null;
+  rsvpPhone?: string | null;
+  rsvpEmail?: string | null;
+  rsvpUrl?: string | null;
+  detailCopy?: string | null;
+  activities?: string[] | null;
+  attire?: string | null;
+  registryUrl?: string | null;
+  ocrFacts?: OcrFact[] | null;
+  actions?: ReactNode;
+};
+
+export default function GenericEventSkin({ categoryLabel, ...props }: Props) {
+  return <ScannedInviteSkin {...props} categoryLabel={categoryLabel || "General Event"} />;
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated visual skin for baby shower events and improve handling of scanned/OCR-generated invites. 
- Use a generic, reusable skin for non-specialized scanned/OCR events so scanned invites render consistently without requiring a specialized component.

### Description
- Add `BabyShowerSkin` component that composes `ScannedInviteSkin` with a baby-shower-specific default palette and layout options.
- Add `GenericEventSkin` component that delegates to `ScannedInviteSkin` and provides a default category label of "General Event".
- Update the event page at `src/app/event/[id]/page.tsx` to import the new skins and to: render `BabyShowerSkin` when `categoryNormalized` is a baby shower, replace the previous `ScannedInviteSkin` fallback with `GenericEventSkin` for scanned invites, and render `GenericEventSkin` for OCR events using header image and normalized OCR data.
- Adjusted OCR/scan branching and `ocrSkin` usage to ensure palette/background/fields are passed through to the new skins.

### Testing
- Built the application with `yarn build` and confirmed the production bundle compiles successfully. 
- Ran the test suite with `yarn test` and observed all tests passing. 
- Ran linting with `yarn lint` and fixed/validated style expectations; lint passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c1784fd4832c9decd82d02acd924)