### PR TITLE
Open Apple Calendar via direct webcal navigation (remove iframe)

### DIFF
--- a/src/utils/calendar-open.ts
+++ b/src/utils/calendar-open.ts
@@ -24,7 +24,7 @@ let lastAppleHref = "";
  *   response as a file download ("Save" dialog) instead of handing off to Calendar.
  * - Replacing `https?://` with `webcal://` is registered to the Calendar app on
  *   macOS and iOS, which avoids the browser download flow for the same resource.
- * - We use a hidden iframe so the invite page stays open (no full-page navigation).
+ * - On Apple OS, we navigate directly to `webcal://` so the native app handoff runs in the same click gesture.
  * - A short debounce avoids duplicate prompts from double-firing handlers (e.g. Strict Mode).
  */
 export function openAppleCalendarIcs(href: string): void {
@@ -39,25 +39,7 @@ export function openAppleCalendarIcs(href: string): void {
 
   if (isAppleOS()) {
     const webcalUrl = abs.replace(/^https?:\/\//i, "webcal://");
-    try {
-      const iframe = document.createElement("iframe");
-      iframe.setAttribute("aria-hidden", "true");
-      iframe.setAttribute("tabindex", "-1");
-      iframe.style.cssText =
-        "position:fixed;width:0;height:0;border:0;opacity:0;pointer-events:none;left:-9999px;top:0;";
-      iframe.src = webcalUrl;
-      document.body.appendChild(iframe);
-      window.setTimeout(() => {
-        try {
-          iframe.remove();
-        } catch {
-          /* ignore */
-        }
-      }, 5000);
-      return;
-    } catch {
-      window.location.assign(webcalUrl);
-    }
+    window.location.assign(webcalUrl);
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Avoid the unreliable hidden iframe approach that could trigger browser download/save dialogs when opening ICS links and ensure the native Calendar handoff occurs in the same click gesture on Apple platforms. 
- Prevent duplicate prompts from double-firing handlers using the existing short debounce and href tracking.

### Description
- Replace the hidden iframe flow with a direct `window.location.assign(webcalUrl)` navigation for Apple OS in `openAppleCalendarIcs`. 
- Preserve `toAbsoluteCalendarUrl`, `isAppleOS`, and the debounce logic using `lastAppleHref` and `lastAppleOpenAt`. 
- Keep the non-Apple fallback behavior of `window.open(abs, "_blank", "noopener,noreferrer")` and `window.location.href = abs` when popups are blocked.

### Testing
- Ran the repository unit tests with `yarn test` and TypeScript type checking with `tsc --noEmit`, and they both completed successfully. 
- Ran linting with `yarn lint` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c4224b88832c9db32e0d23b89e6a)