### PR TITLE
Fix mobile scroll lock in concierge chat pane

### DIFF
--- a/src/app/chat/ConciergeChatClient.tsx
+++ b/src/app/chat/ConciergeChatClient.tsx
@@ -1590,7 +1590,7 @@ export default function ConciergeChatClient() {
                   mobileView === "chat"
                     ? isEmptyState
                       ? "flex flex-col overflow-y-auto"
-                      : "flex flex-col overflow-hidden"
+                      : "flex flex-col overflow-y-auto"
                     : "hidden md:flex"
                 } ${shouldShowWorkspacePanel ? "" : "md:border-r-0"}`}
               >


### PR DESCRIPTION
### Motivation
- Ensure the mobile `/chat` column remains vertically scrollable so users are not stuck at the bottom of the chat pane when the empty-state changes to an active conversation.

### Description
- Change in `src/app/chat/ConciergeChatClient.tsx` to use `overflow-y-auto` for the mobile `chat` branch in the chat pane class so both empty and non-empty states allow vertical scrolling while preserving the `isEmptyState` ternary shape required by source-guard tests.

### Testing
- Ran `node --test src/app/chat/page.test.mjs` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90a49b198832c909da0333318c2d0)