### PR TITLE
Mobile Create with AI: open chat and hide sidebar

### DIFF
--- a/src/app/left-sidebar.controller.ts
+++ b/src/app/left-sidebar.controller.ts
@@ -852,9 +852,25 @@ export function useLeftSidebarController({
 
   const openAiThreadsPage = useCallback(() => {
     clearEventContext();
+    if (!isDesktop) {
+      setSidebarPage("aiThreads");
+      collapseSidebarOnTouch();
+      router.push("/chat");
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("envitefy:chat:new"));
+      }
+      return;
+    }
     setIsCollapsed(false);
     setSidebarPage("aiThreads");
-  }, [clearEventContext, setIsCollapsed, setSidebarPage]);
+  }, [
+    clearEventContext,
+    collapseSidebarOnTouch,
+    isDesktop,
+    router,
+    setIsCollapsed,
+    setSidebarPage,
+  ]);
 
   const startNewAiChat = useCallback(() => {
     clearEventContext();

--- a/src/app/left-sidebar.create-access.test.mjs
+++ b/src/app/left-sidebar.create-access.test.mjs
@@ -96,9 +96,9 @@ test("left sidebar exposes signed-in AI create entry", () => {
     /const startNewAiChat = useCallback\(\(\) => \{[\s\S]*?setSidebarPage\("aiThreads"\)/,
   );
   assert.match(controllerSource, /window\.dispatchEvent\(new CustomEvent\("envitefy:chat:new"\)\)/);
-  assert.doesNotMatch(
+  assert.match(
     controllerSource,
-    /const openAiThreadsPage = useCallback\(\(\) => \{[\s\S]*?router\.push\("\/chat"\)/,
+    /const openAiThreadsPage = useCallback\(\(\) => \{[\s\S]*?if \(!isDesktop\) \{[\s\S]*?router\.push\("\/chat"\)[\s\S]*?envitefy:chat:new/s,
   );
   assert.match(modelSource, /\|\s*"aiThreads"/);
 });


### PR DESCRIPTION
### Motivation
- On mobile tapping the `Create with AI` entry should open a new chat session and hide the left-side drawer instead of just opening the AI threads panel inside the sidebar.

### Description
- Changed `openAiThreadsPage` in `src/app/left-sidebar.controller.ts` to detect mobile (`!isDesktop`) and then `setSidebarPage("aiThreads")`, call `collapseSidebarOnTouch()`, `router.push("/chat")`, and dispatch `envitefy:chat:new`, while keeping desktop behavior unchanged.
- Updated the source-shape regression assertion in `src/app/left-sidebar.create-access.test.mjs` to expect the new mobile-only routing and event dispatch path.

### Testing
- Ran `node --test src/app/left-sidebar.create-access.test.mjs` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95c45cb28832c98ad71c037196d70)