### PR TITLE
Improve mobile /chat scrolling and use 3-column starter categories

### DIFF
--- a/src/app/chat/ConciergeChatClient.tsx
+++ b/src/app/chat/ConciergeChatClient.tsx
@@ -361,7 +361,7 @@ function ChatStudioStarterGrid({
   isUploading: boolean;
 }) {
   return (
-    <div className="grid auto-rows-[118px] grid-cols-2 gap-2.5 sm:auto-rows-[135px] sm:grid-cols-6 md:auto-rows-[155px]">
+    <div className="grid auto-rows-[92px] grid-cols-3 gap-2 sm:auto-rows-[130px] sm:grid-cols-6 md:auto-rows-[155px]">
       {CHAT_STUDIO_GRID_ITEMS.map((item, index) => (
         <div key={item.key} className={CHAT_STUDIO_GRID_PLACEMENT_CLASS[item.key]}>
           {item.kind === "upload" ? (
@@ -1539,7 +1539,7 @@ export default function ConciergeChatClient() {
   );
 
   return (
-    <div className="flex h-screen w-full overflow-hidden bg-[#f8f9fc] text-[#161129]">
+    <div className="flex h-screen w-full overflow-x-hidden bg-[#f8f9fc] text-[#161129] md:overflow-hidden">
       <main ref={mainRef} className="relative flex h-full min-w-0 flex-1 flex-col overflow-hidden">
         <div className="relative z-10 flex min-h-0 flex-1 flex-col">
           <header className="flex h-14 shrink-0 items-center justify-between border-b border-[#eee8f6] bg-white px-4 md:hidden">
@@ -1589,8 +1589,8 @@ export default function ConciergeChatClient() {
                 } ${
                   mobileView === "chat"
                     ? isEmptyState
-                      ? "flex flex-col overflow-y-auto"
-                      : "flex flex-col overflow-y-auto"
+                      ? "flex flex-col overflow-y-auto [overscroll-behavior-y:contain] [touch-action:pan-y] [-webkit-overflow-scrolling:touch]"
+                      : "flex flex-col overflow-y-auto [overscroll-behavior-y:contain] [touch-action:pan-y] [-webkit-overflow-scrolling:touch]"
                     : "hidden md:flex"
                 } ${shouldShowWorkspacePanel ? "" : "md:border-r-0"}`}
               >

--- a/src/app/chat/page.test.mjs
+++ b/src/app/chat/page.test.mjs
@@ -22,8 +22,8 @@ test("/chat is the OpenAI-backed concierge workspace", () => {
   assert.match(client, /or just start chatting/);
   assert.match(client, /STUDIO_CATEGORY_TILES/);
   assert.match(client, /CHAT_STUDIO_GRID_COMPOSITION/);
-  assert.match(client, /auto-rows-\[118px\]/);
-  assert.match(client, /sm:auto-rows-\[135px\]/);
+  assert.match(client, /auto-rows-\[92px\]/);
+  assert.match(client, /sm:auto-rows-\[130px\]/);
   assert.match(client, /md:auto-rows-\[155px\]/);
   assert.match(client, /max-w-\[90rem\]/);
   assert.match(client, /Upload Your Invite/);
@@ -63,7 +63,7 @@ test("/chat is the OpenAI-backed concierge workspace", () => {
   assert.match(client, /shouldShowWorkspacePanel/);
   assert.match(client, /Boolean\(draft\)/);
   assert.match(client, /mobileView/);
-  assert.match(client, /isEmptyState\s*\?\s*"flex flex-col overflow-y-auto"/);
+  assert.match(client, /isEmptyState\s*\?\s*"flex flex-col overflow-y-auto \[overscroll-behavior-y:contain\] \[touch-action:pan-y\] \[-webkit-overflow-scrolling:touch\]"/);
   assert.match(client, /setMobileView\("preview"\)/);
   assert.match(client, /Workspace Preview/);
   assert.match(client, /Invitation/);


### PR DESCRIPTION
### Motivation
- Mobile users could not reliably swipe up in `/chat`, and the starter category tiles didn’t fit in one view on small screens. The changes aim to restore touch-friendly vertical scrolling and surface more categories at once.
- Make the starter category grid denser on narrow viewports so the initial empty-state view shows more options without scrolling.

### Description
- Updated the starter grid in `ChatStudioStarterGrid` to use a 3-column mobile layout and tighter rows by changing the class from `grid auto-rows-[118px] grid-cols-2 ...` to `grid auto-rows-[92px] grid-cols-3 ...` and adjusted the `sm:` row sizes accordingly in `src/app/chat/ConciergeChatClient.tsx`.
- Relaxed the root overflow handling on the chat page by replacing `overflow-hidden` with `overflow-x-hidden md:overflow-hidden` to avoid trapping vertical gestures on mobile in `src/app/chat/ConciergeChatClient.tsx`.
- Enabled touch-friendly vertical panning, momentum scrolling, and contained overscroll behavior on the chat pane by adding `[overscroll-behavior-y:contain] [touch-action:pan-y] [-webkit-overflow-scrolling:touch]` to the mobile `isEmptyState` classes in `src/app/chat/ConciergeChatClient.tsx`.
- Updated the source-shape regression test `src/app/chat/page.test.mjs` to match the new grid sizing and the added mobile overflow classes (`auto-rows-[92px]`, `sm:auto-rows-[130px]`, and the expanded `isEmptyState` class string).

### Testing
- Ran the focused source-shape test: `node --test src/app/chat/page.test.mjs`, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95dc8d104832c8197e6e7e4a4ab28)