### PR TITLE
Fix mobile chat empty-state scroll clearance

### DIFF
--- a/src/app/chat/ConciergeChatClient.tsx
+++ b/src/app/chat/ConciergeChatClient.tsx
@@ -1598,7 +1598,10 @@ export default function ConciergeChatClient() {
                 } ${shouldShowWorkspacePanel ? "" : "md:border-r-0"}`}
               >
                 {isEmptyState ? (
-                  <div className="mx-auto flex min-h-full w-full max-w-[90rem] flex-col justify-end px-4 pb-56 pt-8 text-center sm:px-6 sm:pb-60">
+                  <div
+                    className="mx-auto flex min-h-full w-full max-w-[90rem] flex-col justify-end px-4 pt-8 text-center sm:px-6"
+                    style={{ paddingBottom: composerBottomPadding }}
+                  >
                     <motion.h1
                       initial={{ opacity: 0, y: 16 }}
                       animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
### Motivation
- Prevent the fixed composer from overlapping the `/chat` empty-state starter cards on mobile by making the empty-state bottom spacing track the measured composer height instead of using hardcoded padding.

### Description
- Replace static `pb-56/sm:pb-60` padding on the empty-state container with a dynamic `style={{ paddingBottom: composerBottomPadding }}` so the empty and non-empty chat flows align to the same measured composer footprint in `src/app/chat/ConciergeChatClient.tsx`.

### Testing
- Ran `node --test src/app/chat/page.test.mjs`, which passed (2 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f963d68088832cab1589df9930e880)