### PR TITLE
Fix mobile chat composer overlap in concierge chat

### DIFF
--- a/src/app/chat/ConciergeChatClient.tsx
+++ b/src/app/chat/ConciergeChatClient.tsx
@@ -645,6 +645,7 @@ export default function ConciergeChatClient() {
   const selectedProductLabel = productLabel(effectiveSelectedProductOutput);
   const currentCategoryLabel = categoryLabelFromDraft(draft, starterCategory);
   const currentPreviewImage = previewImageForDraft(draft, starterCategory);
+  const mobileComposerSpacer = `calc(${composerBottomPadding}px + env(safe-area-inset-bottom) + 1.25rem)`;
 
   function selectProductOutputForDraft(nextDraft: ConciergeEventDraft) {
     const restoredOutput = nextDraft.requestedOutputs.find((output) =>
@@ -1099,7 +1100,7 @@ export default function ConciergeChatClient() {
   const chatThread = (
     <div
       className="mx-auto flex min-h-full w-full max-w-3xl flex-col justify-end gap-5 px-4 pb-56 pt-8 sm:px-6 sm:pb-60"
-      style={{ paddingBottom: composerBottomPadding }}
+      style={{ paddingBottom: mobileComposerSpacer }}
       role="log"
       aria-live="polite"
       aria-relevant="additions text"
@@ -1600,7 +1601,7 @@ export default function ConciergeChatClient() {
                 {isEmptyState ? (
                   <div
                     className="mx-auto flex min-h-full w-full max-w-[90rem] flex-col justify-end px-4 pt-8 text-center sm:px-6"
-                    style={{ paddingBottom: composerBottomPadding }}
+                    style={{ paddingBottom: mobileComposerSpacer }}
                   >
                     <motion.h1
                       initial={{ opacity: 0, y: 16 }}


### PR DESCRIPTION
### Motivation
- On mobile the fixed chat composer was overlapping the category grid and chat thread content, preventing scrolling to items near the bottom. 
- Reserve explicit bottom spacing equal to the composer height plus the safe-area inset so content can scroll clear of the fixed input bar.

### Description
- Added a `mobileComposerSpacer` computed as `calc(${composerBottomPadding}px + env(safe-area-inset-bottom) + 1.25rem)` in `ConciergeChatClient` to include composer height, safe-area inset, and extra breathing room. 
- Applied `mobileComposerSpacer` to the chat thread container and the empty-state category grid by setting their `paddingBottom` styles in `src/app/chat/ConciergeChatClient.tsx` so both states clear the fixed composer.

### Testing
- Ran `npx biome lint src/app/chat/ConciergeChatClient.tsx` which completed without errors for the touched file. 
- Ran `npm run lint -- src/app/chat/ConciergeChatClient.tsx` which fails repo-wide due to unrelated pre-existing lint issues outside the changed file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f965e98cbc832ca08c151c2f722ecb)