### PR TITLE
Center composer with CSS, adjust studio grid placement, and hide mobile topbar on /chat

### DIFF
--- a/src/app/chat/ConciergeChatClient.tsx
+++ b/src/app/chat/ConciergeChatClient.tsx
@@ -217,7 +217,7 @@ const CHAT_STUDIO_GRID_PLACEMENT_CLASS: Record<ChatStudioGridTileKey, string> = 
   upload: "col-start-3 row-start-1 sm:col-start-3 sm:row-start-1",
   "Game Day": "col-start-1 row-start-2",
   "Field Trip/Day": "col-start-2 row-start-2",
-  Wedding: "col-start-3 row-start-2 sm:col-start-6 sm:row-span-2 sm:row-start-1",
+  Wedding: "col-span-2 col-start-1 row-start-5 sm:col-span-2 sm:col-start-1 sm:row-start-1",
   "Bridal Shower": "col-start-1 row-start-3 sm:col-start-4 sm:row-start-1",
   "Baby Shower": "col-start-2 row-start-3 sm:col-start-5 sm:row-start-1",
   "Open House": "col-start-3 row-start-3 sm:col-start-3 sm:row-start-2",
@@ -595,7 +595,6 @@ export default function ConciergeChatClient() {
   const [isListening, setIsListening] = useState(false);
   const [mobileView, setMobileView] = useState<"chat" | "preview">("chat");
   const [previewTab, setPreviewTab] = useState<"preview" | "rsvp">("preview");
-  const [composerCenterLeft, setComposerCenterLeft] = useState("50vw");
   const [composerBottomPadding, setComposerBottomPadding] = useState(224);
 
   const isGeneratingCard = phase === "generating_card";
@@ -753,30 +752,6 @@ export default function ConciergeChatClient() {
       cancelled = true;
     };
   }, [threadId]);
-
-  useEffect(() => {
-    function updateComposerCenter() {
-      const target = shouldShowWorkspacePanel
-        ? chatPaneRef.current || mainRef.current
-        : mainRef.current;
-      const rect = target?.getBoundingClientRect();
-      if (!rect) {
-        setComposerCenterLeft("50vw");
-        return;
-      }
-      setComposerCenterLeft(`${rect.left + rect.width / 2}px`);
-    }
-
-    updateComposerCenter();
-    const frame = window.requestAnimationFrame(updateComposerCenter);
-    const timeout = window.setTimeout(updateComposerCenter, 260);
-    window.addEventListener("resize", updateComposerCenter);
-    return () => {
-      window.cancelAnimationFrame(frame);
-      window.clearTimeout(timeout);
-      window.removeEventListener("resize", updateComposerCenter);
-    };
-  }, [shouldShowWorkspacePanel]);
 
   useEffect(() => {
     const composer = composerCardRef.current;
@@ -1634,10 +1609,9 @@ export default function ConciergeChatClient() {
           </section>
 
           <div
-            className={`pointer-events-none fixed bottom-0 z-30 w-[calc(100vw-1rem)] -translate-x-1/2 flex-col items-stretch pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-10 sm:w-[calc(100vw-3rem)] sm:pb-8 ${
+            className={`pointer-events-none sticky bottom-0 z-30 mx-auto flex w-full max-w-3xl flex-col items-stretch px-2 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-4 sm:w-[calc(100vw-3rem)] sm:pb-8 md:fixed md:bottom-0 md:w-[calc(100vw-1rem)] md:px-0 md:pt-10 ${
               shouldShowWorkspacePanel && mobileView === "preview" ? "hidden md:flex" : "flex"
-            } max-w-3xl`}
-            style={{ left: composerCenterLeft }}
+            } md:left-1/2 md:-translate-x-1/2`}
           >
             <div ref={composerCardRef} className="pointer-events-auto w-full">
               <form onSubmit={handleSubmit}>

--- a/src/app/left-sidebar.tsx
+++ b/src/app/left-sidebar.tsx
@@ -1231,7 +1231,7 @@ export default function LeftSidebar() {
 
   return (
     <>
-      {!viewModel.isOpen ? (
+      {!viewModel.isOpen && pathname !== "/chat" ? (
         <header
           data-app-mobile-topbar="workspace"
           className={`fixed inset-x-0 top-0 z-[6500] px-3 pb-2 pt-[max(0.75rem,env(safe-area-inset-top))] transition-all duration-300 ease-in-out lg:hidden ${


### PR DESCRIPTION
### Motivation

- Simplify and stabilize composer centering using CSS instead of runtime measurement and avoid layout jitter when workspace panel toggles.
- Fix the Chat Studio grid placement for the Wedding tile to match the intended responsive layout.
- Prevent the mobile workspace topbar from rendering on the main `/chat` route to avoid UI duplication.

### Description

- Replaced dynamic `composerCenterLeft` state and its `useEffect` with CSS-based centering by changing the composer container from a `fixed` positioned element with inline `left` to a responsive `sticky`/`md:fixed` layout that uses `mx-auto` and `md:left-1/2 md:-translate-x-1/2` for centering, and adjusted base padding and spacing classes.
- Removed the `composerCenterLeft` state declaration and the corresponding resize/animation effect that computed the inline left position.
- Updated `CHAT_STUDIO_GRID_PLACEMENT_CLASS` to reposition the `Wedding` tile to use `col-span-2 col-start-1 row-start-5 sm:col-span-2 sm:col-start-1 sm:row-start-1` for the intended grid composition.
- Changed left sidebar mobile header rendering so the header is not shown when `pathname === "/chat"` by updating the conditional from `!viewModel.isOpen` to `!viewModel.isOpen && pathname !== "/chat"`.

### Testing

- Ran TypeScript type check with `tsc --noEmit` which completed successfully.
- Executed the test suite with `pnpm test` and all tests passed.
- Ran linter with `pnpm lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96ab7d128832cbd8d6258f34b3082)