### PR TITLE
Restore chat top bar and re-enable scrolling in Concierge Chat

### DIFF
--- a/src/app/chat/ConciergeChatClient.tsx
+++ b/src/app/chat/ConciergeChatClient.tsx
@@ -1515,10 +1515,10 @@ export default function ConciergeChatClient() {
   );
 
   return (
-    <div className="flex min-h-screen w-full overflow-x-hidden bg-[#f8f9fc] text-[#161129] md:h-screen md:overflow-hidden">
+    <div className="flex min-h-screen w-full overflow-x-hidden bg-[#f8f9fc] text-[#161129]">
       <main
         ref={mainRef}
-        className="relative flex min-h-screen min-w-0 flex-1 flex-col overflow-y-auto md:h-full md:min-h-0 md:overflow-hidden"
+        className="relative flex min-h-screen min-w-0 flex-1 flex-col overflow-y-auto"
       >
         <div className="relative z-10 flex min-h-0 flex-1 flex-col">
           <header className="flex h-14 shrink-0 items-center justify-between border-b border-[#eee8f6] bg-white px-4 md:hidden">

--- a/src/app/left-sidebar.tsx
+++ b/src/app/left-sidebar.tsx
@@ -1231,7 +1231,7 @@ export default function LeftSidebar() {
 
   return (
     <>
-      {!viewModel.isOpen && pathname !== "/chat" ? (
+      {!viewModel.isOpen ? (
         <header
           data-app-mobile-topbar="workspace"
           className={`fixed inset-x-0 top-0 z-[6500] px-3 pb-2 pt-[max(0.75rem,env(safe-area-inset-top))] transition-all duration-300 ease-in-out lg:hidden ${


### PR DESCRIPTION
### Motivation
- The chat mobile topbar was being suppressed on `/chat` and the chat shell contained CSS that prevented vertical scrolling on mobile, breaking the expected touch/scroll behavior. 

### Description
- Removed the chat-specific suppression so the mobile workspace topbar renders normally by changing the condition in `src/app/left-sidebar.tsx`. 
- Restored document flow on the chat page by removing the desktop-only scroll-lock classes from the top-level chat shell and main container in `src/app/chat/ConciergeChatClient.tsx`. 
- Changes are limited to small `className`/condition edits in `left-sidebar.tsx` and `ConciergeChatClient.tsx` to restore the prior mobile scrolling and header behavior. 

### Testing
- Ran `npm run lint -- src/app/chat/ConciergeChatClient.tsx src/app/left-sidebar.tsx`, which invoked the repository linter and surfaced unrelated Biome diagnostics from other files, causing the lint step to fail (diagnostics are unrelated to these edits). 
- No unit tests were changed or executed as part of this PR; local smoke testing was limited to verifying the header appears on `/chat` and that vertical scrolling is re-enabled on the chat page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f973f9e508832c946d11baf8a92668)