### PR TITLE
Show last scan/upload/snap date in Admin All Users view

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -593,11 +593,21 @@ export default function AdminPage() {
                           </div>
 
                           <div className="flex items-end justify-between gap-3 pt-2 border-t border-[#e5defa]">
-                            <div>
-                              <p className="text-xs uppercase tracking-wider text-[#8b7fb6] mb-1">
-                                Joined
-                              </p>
-                              <p className="text-sm text-[#5b4d86]">{formatDate(u.created_at)}</p>
+                            <div className="space-y-2">
+                              <div>
+                                <p className="text-xs uppercase tracking-wider text-[#8b7fb6] mb-1">
+                                  Last scan/upload/snap
+                                </p>
+                                <p className="text-sm text-[#5b4d86]">
+                                  {formatDate(u.last_scan_created_at)}
+                                </p>
+                              </div>
+                              <div>
+                                <p className="text-xs uppercase tracking-wider text-[#8b7fb6] mb-1">
+                                  Joined
+                                </p>
+                                <p className="text-sm text-[#5b4d86]">{formatDate(u.created_at)}</p>
+                              </div>
                             </div>
                             <button
                               type="button"
@@ -625,6 +635,7 @@ export default function AdminPage() {
                           <th className="px-4 py-3">Email</th>
                           <th className="px-4 py-3 text-right">Scans</th>
                           <th className="px-4 py-3">Events</th>
+                          <th className="px-4 py-3">Last scan/upload/snap</th>
                           <th className="px-4 py-3">Joined</th>
                           <th className="px-4 py-3 text-right">Actions</th>
                         </tr>
@@ -660,6 +671,9 @@ export default function AdminPage() {
                                   count={eventTotal}
                                   breakdown={eventBreakdown}
                                 />
+                              </td>
+                              <td className="px-4 py-3 text-foreground/80 whitespace-nowrap">
+                                {formatDate(u.last_scan_created_at)}
                               </td>
                               <td className="px-4 py-3 text-foreground/80 whitespace-nowrap">
                                 {formatDate(u.created_at)}

--- a/src/lib/admin-user-metrics-sql.ts
+++ b/src/lib/admin-user-metrics-sql.ts
@@ -19,10 +19,12 @@ export const ADMIN_USER_METRICS_CTE_SQL = `
       coalesce(sum(case when is_scan and category like '%doctor%' then 1 else 0 end), 0)::integer as scans_from_history_doctor_appointments,
       coalesce(sum(case when is_scan and category like '%play%' then 1 else 0 end), 0)::integer as scans_from_history_play_days,
       coalesce(sum(case when is_scan and category like '%general%' then 1 else 0 end), 0)::integer as scans_from_history_general_events,
-      coalesce(sum(case when is_scan and (category like '%car%' or category like '%pool%') then 1 else 0 end), 0)::integer as scans_from_history_car_pool
+      coalesce(sum(case when is_scan and (category like '%car%' or category like '%pool%') then 1 else 0 end), 0)::integer as scans_from_history_car_pool,
+      max(case when is_scan then created_at else null end) as last_scan_created_at
     from (
       select
         user_id,
+        created_at,
         lower(coalesce(data->>'category', '')) as category,
         (
           lower(coalesce(data->>'createdVia', '')) = 'ocr'
@@ -67,7 +69,8 @@ export const ADMIN_USER_METRICS_CTE_SQL = `
       coalesce(em.events_doctor_appointments, 0)::integer as events_doctor_appointments,
       coalesce(em.events_play_days, 0)::integer as events_play_days,
       coalesce(em.events_general_events, 0)::integer as events_general_events,
-      coalesce(em.events_car_pool, 0)::integer as events_car_pool
+      coalesce(em.events_car_pool, 0)::integer as events_car_pool,
+      em.last_scan_created_at
     from users u
     left join event_metrics em on em.user_id = u.id
     left join share_metrics sm on sm.user_id = u.id
@@ -81,5 +84,6 @@ export const ADMIN_USER_METRICS_SELECT_SQL = `
   scans_general_events, scans_car_pool,
   events_total, events_birthdays, events_weddings, events_sport_events,
   events_appointments, events_doctor_appointments, events_play_days,
-  events_general_events, events_car_pool
+  events_general_events, events_car_pool,
+  last_scan_created_at
 `;


### PR DESCRIPTION
### Motivation
- Provide admins with a quick way to see when a user last created an event via scan/upload/snap so they can triage activity and usage.

### Description
- Compute `last_scan_created_at` in the admin user metrics CTE by taking `max(created_at)` for `event_history` rows identified as scans/uploads/snaps and expose it in the shared metrics select list (`ADMIN_USER_METRICS_CTE_SQL` / `ADMIN_USER_METRICS_SELECT_SQL`).
- Surface the new field in the `/admin` All Users UI by adding a `Last scan/upload/snap` column to the desktop table and showing the same value in the mobile user card layout (`src/app/admin/page.tsx`).
- Changes touch `src/lib/admin-user-metrics-sql.ts` and `src/app/admin/page.tsx`.

### Testing
- Ran the project linter with `npm run lint -- src/app/admin/page.tsx src/lib/admin-user-metrics-sql.ts`, which exited non-zero due to unrelated, pre-existing Biome diagnostics across the repo and did not introduce new diagnostics in the touched files.  
- Manually inspected the updated SQL and admin page to confirm the `last_scan_created_at` field is selected and rendered in both desktop and mobile views.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4f972590832c993aaf59c94f6bde)