### PR TITLE
Format admin last scan/upload/snap date as MM/DD/YYYY

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -599,7 +599,7 @@ export default function AdminPage() {
                                   Last scan/upload/snap
                                 </p>
                                 <p className="text-sm text-[#5b4d86]">
-                                  {formatDate(u.last_scan_created_at)}
+                                  {formatDate(u.last_scan_created_at, { forceUsNumeric: true })}
                                 </p>
                               </div>
                               <div>
@@ -673,7 +673,7 @@ export default function AdminPage() {
                                 />
                               </td>
                               <td className="px-4 py-3 text-foreground/80 whitespace-nowrap">
-                                {formatDate(u.last_scan_created_at)}
+                                {formatDate(u.last_scan_created_at, { forceUsNumeric: true })}
                               </td>
                               <td className="px-4 py-3 text-foreground/80 whitespace-nowrap">
                                 {formatDate(u.created_at)}
@@ -996,11 +996,18 @@ function _Td({ children, className }: { children: any; className?: string }) {
   return <td className={`px-4 py-3 text-muted-foreground ${className || ""}`}>{children}</td>;
 }
 
-function formatDate(value?: string) {
+function formatDate(value?: string, options?: { forceUsNumeric?: boolean }) {
   if (!value) return "-";
   try {
     const d = new Date(value);
     if (Number.isNaN(d.getTime())) return "-";
+    if (options?.forceUsNumeric) {
+      return new Intl.DateTimeFormat("en-US", {
+        month: "2-digit",
+        day: "2-digit",
+        year: "numeric",
+      }).format(d);
+    }
     return d.toLocaleDateString();
   } catch {
     return "-";


### PR DESCRIPTION
### Motivation
- Ensure the "Last scan/upload/snap" field in the admin UI always displays a US numeric date (`MM/DD/YYYY`) instead of a locale-dependent format.

### Description
- Extend `formatDate(value?: string)` to `formatDate(value?: string, options?: { forceUsNumeric?: boolean })` to allow an explicit formatting mode.
- When `options?.forceUsNumeric` is set, format with `new Intl.DateTimeFormat("en-US", { month: "2-digit", day: "2-digit", year: "numeric" })` to produce `MM/DD/YYYY`.
- Apply the forced-US format to the `last_scan_created_at` display in both the mobile card and desktop table views.
- Leave other date fields (for example `created_at` / "Joined") unchanged.

### Testing
- Ran `npm run lint -- src/app/admin/page.tsx`, which executed Biome and surfaced pre-existing repository-wide diagnostics unrelated to this change and caused the lint step to fail.
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5f706730832c92817f9d1de5b36d)