### PR TITLE
Map Amazon registry OCR links by event type

### DIFF
--- a/src/lib/ocr/pipeline.ts
+++ b/src/lib/ocr/pipeline.ts
@@ -71,6 +71,7 @@ import {
 } from "@/lib/ocr/text";
 import { rasterizePdfPageToPng } from "@/lib/pdf-raster";
 import { normalizeThumbnailFocus } from "@/lib/thumbnail-focus";
+import { normalizeRegistryUrlForDetectedEvent } from "@/lib/ocr/registry-url";
 import { validateUploadFileMeta } from "@/lib/upload-config";
 
 function toLocalNoZ(date: Date | null) {
@@ -1266,10 +1267,16 @@ export async function handleOcrRequest(request: Request) {
         typeof llmImage?.attire === "string" && llmImage.attire.trim()
           ? llmImage.attire.trim()
           : null,
-      registryUrl:
-        typeof llmImage?.registryUrl === "string" && llmImage.registryUrl.trim()
-          ? llmImage.registryUrl.trim()
-          : null,
+      registryUrl: normalizeRegistryUrlForDetectedEvent({
+        category: llmImage?.category || null,
+        title: finalTitle,
+        description,
+        rawText: raw,
+        registryUrl:
+          typeof llmImage?.registryUrl === "string" && llmImage.registryUrl.trim()
+            ? llmImage.registryUrl.trim()
+            : null,
+      }),
     };
 
     const tz = fieldsGuess.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
@@ -1603,6 +1610,14 @@ export async function handleOcrRequest(request: Request) {
     if (isPickleballOcrEvent || isFootballOcrEvent || isBasketballOcrEvent) {
       category = "Sport Events";
     }
+    fieldsGuess.registryUrl = normalizeRegistryUrlForDetectedEvent({
+      category,
+      title: fieldsGuess.title || finalTitle,
+      description: fieldsGuess.description || description,
+      rawText: raw,
+      registryUrl: fieldsGuess.registryUrl,
+    });
+
     if (category === "Graduations") {
       const cleanedVenue = cleanGraduationVenueName(fieldsGuess.venue);
       fieldsGuess.venue = cleanedVenue || null;

--- a/src/lib/ocr/registry-url.source.test.mjs
+++ b/src/lib/ocr/registry-url.source.test.mjs
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+test("registry URL normalizer maps Amazon to event-type specific registry URLs", () => {
+  const source = readFileSync(new URL("./registry-url.ts", import.meta.url), "utf8");
+  assert.match(source, /https:\/\/www\.amazon\.com\/baby-reg\/homepage/);
+  assert.match(source, /https:\/\/www\.amazon\.com\/registries\/search/);
+  assert.match(source, /https:\/\/www\.amazon\.com\/registries\/birthday/);
+  assert.match(source, /registered\\s\+at\\s\+amazon/);
+  assert.match(source, /bridal/);
+});

--- a/src/lib/ocr/registry-url.ts
+++ b/src/lib/ocr/registry-url.ts
@@ -1,0 +1,67 @@
+const AMAZON_BABY_REGISTRY_URL = "https://www.amazon.com/baby-reg/homepage";
+const AMAZON_WEDDING_REGISTRY_URL = "https://www.amazon.com/registries/search";
+const AMAZON_BIRTHDAY_REGISTRY_URL = "https://www.amazon.com/registries/birthday";
+
+function normalizeCategory(value: string | null | undefined): string {
+  return String(value || "")
+    .trim()
+    .toLowerCase();
+}
+
+function hasAmazonRegistryCue(rawText: string | null | undefined): boolean {
+  const normalized = String(rawText || "").toLowerCase();
+  return /\bregistered\s+at\s+amazon\b/.test(normalized);
+}
+
+function isAmazonRootUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    if (!hostname.endsWith("amazon.com")) return false;
+    return parsed.pathname === "/" || parsed.pathname === "";
+  } catch {
+    return false;
+  }
+}
+
+function chooseAmazonRegistryUrlFromEventType(input: {
+  category: string | null | undefined;
+  title: string | null | undefined;
+  description: string | null | undefined;
+  rawText: string | null | undefined;
+}): string {
+  const category = normalizeCategory(input.category);
+  const signals = [input.title, input.description, input.rawText, input.category]
+    .map((value) => String(value || "").toLowerCase())
+    .join("\n");
+
+  if (category.includes("birthday") || /\bbirthday\b/.test(signals)) {
+    return AMAZON_BIRTHDAY_REGISTRY_URL;
+  }
+  if (category.includes("wedding") || /\b(wedding|bridal)\b/.test(signals)) {
+    return AMAZON_WEDDING_REGISTRY_URL;
+  }
+  if (category.includes("baby") || /\bbaby\s*(shower|sprinkle)?\b/.test(signals)) {
+    return AMAZON_BABY_REGISTRY_URL;
+  }
+
+  return AMAZON_WEDDING_REGISTRY_URL;
+}
+
+export function normalizeRegistryUrlForDetectedEvent(input: {
+  category: string | null | undefined;
+  title: string | null | undefined;
+  description: string | null | undefined;
+  rawText: string | null | undefined;
+  registryUrl: string | null | undefined;
+}): string | null {
+  const registryUrl = typeof input.registryUrl === "string" ? input.registryUrl.trim() : "";
+  if (!registryUrl && !hasAmazonRegistryCue(input.rawText)) return null;
+
+  if (!registryUrl || isAmazonRootUrl(registryUrl) || hasAmazonRegistryCue(input.rawText)) {
+    return chooseAmazonRegistryUrlFromEventType(input);
+  }
+
+  return registryUrl;
+}


### PR DESCRIPTION
### Motivation
- Ensure OCR-detected generic Amazon mentions like `Registered at Amazon` become useful registry links by mapping them to event-type-specific Amazon pages (baby, wedding/bridal, birthday) instead of a bare `amazon.com` root.
- Make the OCR pipeline aware of event type so registry links inserted during scan are appropriate to the detected category.

### Description
- Added a new module `src/lib/ocr/registry-url.ts` that detects Amazon registry cues and maps to specific URLs using `normalizeRegistryUrlForDetectedEvent` and a `/registered\s+at\s+amazon/` heuristic.
- Wired the normalizer into the OCR assembly by replacing the initial `fieldsGuess.registryUrl` assignment to call `normalizeRegistryUrlForDetectedEvent` during first extraction. (`src/lib/ocr/pipeline.ts`)
- Added a second normalization pass after final category resolution to re-evaluate `fieldsGuess.registryUrl` in case the detected category changed later in the pipeline. (`src/lib/ocr/pipeline.ts`)
- Added a source-shape regression test `src/lib/ocr/registry-url.source.test.mjs` that asserts the new module contains the expected Amazon mapping URLs and cues.

### Testing
- Ran `node --test src/lib/ocr/registry-url.source.test.mjs` which passed and verifies the mapping constants and cues are present.
- Ran `node --test src/components/Dashboard.ocr-skin.source.test.mjs` which passed to ensure no regressions in OCR skin handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe62de5698832c96ddf17378c0988c)