### PR TITLE
Normalize detected and legacy registry URLs (Amazon mapping)

### DIFF
--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -53,6 +53,7 @@ import { getEventTheme } from "@/lib/event-theme";
 import { invalidateUserHistory } from "@/lib/history-cache";
 import { combineVenueAndLocation } from "@/lib/mappers";
 import { buildOcrFacts, mergeOcrFacts, normalizeOcrFacts } from "@/lib/ocr/facts";
+import { normalizeRegistryUrlForDetectedEvent } from "@/lib/ocr/registry-url";
 import {
   isBasketballOcrSkinCandidate,
   isFootballOcrSkinCandidate,
@@ -1105,9 +1106,25 @@ export default async function EventPage({
   const registryCopy = getRegistrySectionCopyForCategory(categoryRaw);
   const registriesAllowed = registryCopy.allowsLinks;
   const registryLinksRaw = Array.isArray(data?.registries) ? (data.registries as any[]) : [];
+  const legacyRegistryUrlRaw =
+    typeof data?.registryUrl === "string" && data.registryUrl.trim() ? data.registryUrl.trim() : null;
+  const legacyRegistryUrlNormalized = normalizeRegistryUrlForDetectedEvent({
+    category: categoryRaw || null,
+    title: title || null,
+    description: typeof data?.description === "string" ? data.description : null,
+    rawText: typeof data?.ocrText === "string" ? data.ocrText : null,
+    registryUrl: legacyRegistryUrlRaw,
+  });
+  const registryLinksWithLegacy =
+    legacyRegistryUrlNormalized &&
+    !registryLinksRaw.some((item: any) =>
+      typeof item?.url === "string" && item.url.trim() === legacyRegistryUrlNormalized,
+    )
+      ? [{ label: "Amazon", url: legacyRegistryUrlNormalized }, ...registryLinksRaw]
+      : registryLinksRaw;
   const registryLinks = registriesAllowed
     ? normalizeRegistryLinks(
-        registryLinksRaw.map((item: any) => ({
+        registryLinksWithLegacy.map((item: any) => ({
           label: typeof item?.label === "string" ? item.label : "",
           url: typeof item?.url === "string" ? item.url : "",
         })),

--- a/src/lib/ocr/pipeline.ts
+++ b/src/lib/ocr/pipeline.ts
@@ -71,6 +71,7 @@ import {
 } from "@/lib/ocr/text";
 import { rasterizePdfPageToPng } from "@/lib/pdf-raster";
 import { normalizeThumbnailFocus } from "@/lib/thumbnail-focus";
+import { normalizeRegistryUrlForDetectedEvent } from "@/lib/ocr/registry-url";
 import { validateUploadFileMeta } from "@/lib/upload-config";
 
 function toLocalNoZ(date: Date | null) {
@@ -1266,10 +1267,16 @@ export async function handleOcrRequest(request: Request) {
         typeof llmImage?.attire === "string" && llmImage.attire.trim()
           ? llmImage.attire.trim()
           : null,
-      registryUrl:
-        typeof llmImage?.registryUrl === "string" && llmImage.registryUrl.trim()
-          ? llmImage.registryUrl.trim()
-          : null,
+      registryUrl: normalizeRegistryUrlForDetectedEvent({
+        category: llmImage?.category || null,
+        title: finalTitle,
+        description,
+        rawText: raw,
+        registryUrl:
+          typeof llmImage?.registryUrl === "string" && llmImage.registryUrl.trim()
+            ? llmImage.registryUrl.trim()
+            : null,
+      }),
     };
 
     const tz = fieldsGuess.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
@@ -1603,6 +1610,14 @@ export async function handleOcrRequest(request: Request) {
     if (isPickleballOcrEvent || isFootballOcrEvent || isBasketballOcrEvent) {
       category = "Sport Events";
     }
+    fieldsGuess.registryUrl = normalizeRegistryUrlForDetectedEvent({
+      category,
+      title: fieldsGuess.title || finalTitle,
+      description: fieldsGuess.description || description,
+      rawText: raw,
+      registryUrl: fieldsGuess.registryUrl,
+    });
+
     if (category === "Graduations") {
       const cleanedVenue = cleanGraduationVenueName(fieldsGuess.venue);
       fieldsGuess.venue = cleanedVenue || null;

--- a/src/lib/ocr/registry-url.source.test.mjs
+++ b/src/lib/ocr/registry-url.source.test.mjs
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+test("registry URL normalizer maps Amazon to event-type specific registry URLs", () => {
+  const source = readFileSync(new URL("./registry-url.ts", import.meta.url), "utf8");
+  assert.match(source, /https:\/\/www\.amazon\.com\/baby-reg\/homepage/);
+  assert.match(source, /https:\/\/www\.amazon\.com\/registries\/search/);
+  assert.match(source, /https:\/\/www\.amazon\.com\/registries\/birthday/);
+  assert.match(source, /registered\\s\+at\\s\+amazon/);
+  assert.match(source, /bridal/);
+});

--- a/src/lib/ocr/registry-url.ts
+++ b/src/lib/ocr/registry-url.ts
@@ -1,0 +1,67 @@
+const AMAZON_BABY_REGISTRY_URL = "https://www.amazon.com/baby-reg/homepage";
+const AMAZON_WEDDING_REGISTRY_URL = "https://www.amazon.com/registries/search";
+const AMAZON_BIRTHDAY_REGISTRY_URL = "https://www.amazon.com/registries/birthday";
+
+function normalizeCategory(value: string | null | undefined): string {
+  return String(value || "")
+    .trim()
+    .toLowerCase();
+}
+
+function hasAmazonRegistryCue(rawText: string | null | undefined): boolean {
+  const normalized = String(rawText || "").toLowerCase();
+  return /\bregistered\s+at\s+amazon\b/.test(normalized);
+}
+
+function isAmazonRootUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    if (!hostname.endsWith("amazon.com")) return false;
+    return parsed.pathname === "/" || parsed.pathname === "";
+  } catch {
+    return false;
+  }
+}
+
+function chooseAmazonRegistryUrlFromEventType(input: {
+  category: string | null | undefined;
+  title: string | null | undefined;
+  description: string | null | undefined;
+  rawText: string | null | undefined;
+}): string {
+  const category = normalizeCategory(input.category);
+  const signals = [input.title, input.description, input.rawText, input.category]
+    .map((value) => String(value || "").toLowerCase())
+    .join("\n");
+
+  if (category.includes("birthday") || /\bbirthday\b/.test(signals)) {
+    return AMAZON_BIRTHDAY_REGISTRY_URL;
+  }
+  if (category.includes("wedding") || /\b(wedding|bridal)\b/.test(signals)) {
+    return AMAZON_WEDDING_REGISTRY_URL;
+  }
+  if (category.includes("baby") || /\bbaby\s*(shower|sprinkle)?\b/.test(signals)) {
+    return AMAZON_BABY_REGISTRY_URL;
+  }
+
+  return AMAZON_WEDDING_REGISTRY_URL;
+}
+
+export function normalizeRegistryUrlForDetectedEvent(input: {
+  category: string | null | undefined;
+  title: string | null | undefined;
+  description: string | null | undefined;
+  rawText: string | null | undefined;
+  registryUrl: string | null | undefined;
+}): string | null {
+  const registryUrl = typeof input.registryUrl === "string" ? input.registryUrl.trim() : "";
+  if (!registryUrl && !hasAmazonRegistryCue(input.rawText)) return null;
+
+  if (!registryUrl || isAmazonRootUrl(registryUrl) || hasAmazonRegistryCue(input.rawText)) {
+    return chooseAmazonRegistryUrlFromEventType(input);
+  }
+
+  return registryUrl;
+}


### PR DESCRIPTION
### Motivation

- Map ambiguous or root Amazon registry mentions discovered by OCR or legacy `registryUrl` fields to event-type specific Amazon registry pages (wedding, baby, birthday) for better user experience.
- Ensure OCR-detected registry cues and legacy plain Amazon links are normalized and surfaced alongside structured `registries` data.

### Description

- Add a new OCR helper `src/lib/ocr/registry-url.ts` that detects Amazon cues and root Amazon links and chooses an event-type specific registry URL based on category, title, description, and raw OCR text.
- Use `normalizeRegistryUrlForDetectedEvent` inside the OCR pipeline (`src/lib/ocr/pipeline.ts`) to normalize `fieldsGuess.registryUrl` when generating OCR-derived event fields.
- Integrate legacy `registryUrl` normalization into the event page (`src/app/event/[id]/page.tsx`) and merge a de-duplicated normalized legacy URL into the `registries` list when appropriate.
- Add a source-level test `src/lib/ocr/registry-url.source.test.mjs` that asserts the normalizer contains expected Amazon mapping patterns.

### Testing

- Added `src/lib/ocr/registry-url.source.test.mjs` which was executed with `node --test` and passed.
- The new `registry-url.ts` file was exercised indirectly by the OCR pipeline changes during local integration checks and did not introduce type or runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe62de5698832c96ddf17378c0988c)