### PR TITLE
Fix concierge RSVP guest count autofill from weak guesses

### DIFF
--- a/src/lib/concierge/fallback.ts
+++ b/src/lib/concierge/fallback.ts
@@ -1880,9 +1880,7 @@ export function fallbackExtractConciergeDraft(args: {
   const timeText = chronoResult.timeText || firstString(fieldsGuess.time);
   const startISO = fieldStartIso || chronoResult.startISO;
   const endISO = fieldEndIso || chronoResult.endISO;
-  const numberOfGuests =
-    detectGuestCount(message, previous) ||
-    firstPositiveNumber(fieldsGuess.numberOfGuests, fieldsGuess.guestCount);
+  const numberOfGuests = detectGuestCount(message, previous);
   const rsvpEnabled = detectRsvpEnabled(message, previous, requestedOutputs, fieldsGuess);
   const rsvpDeadline = detectRsvpDeadline(text, previous);
   const rsvpContact = detectRsvpContact(text, fieldsGuess, previous);


### PR DESCRIPTION
### Motivation
- Avoid accidental completion of concierge drafts when unrelated numbers in chat (age, milestones, etc.) were being used to populate `numberOfGuests`, which made the flow skip the intended RSVP guest-count follow-up and caused the UI to not show the expected "Keep editing / Generate now" state.

### Description
- Remove the weak fallback that used `firstPositiveNumber(fieldsGuess.numberOfGuests, fieldsGuess.guestCount)` so `numberOfGuests` is now set only from explicit guest-count language via `detectGuestCount(message, previous)` (see `src/lib/concierge/fallback.ts`).

### Testing
- Ran `node --test src/lib/concierge/fallback.test.ts` which completed successfully with all tests passing (88 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038705b190832cb92e05611228387c)