### PR TITLE
Reduce mobile scan overlay flicker in chat upload flow

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1967,7 +1967,7 @@ export default function Dashboard({
         </div>
       )}
       {scanStatus !== "idle" && (
-        <div className="fixed inset-y-0 left-0 right-0 z-[65] flex items-center justify-center bg-[#f4eeff]/78 p-4 backdrop-blur-md lg:left-[20rem]">
+        <div className="fixed inset-y-0 left-0 right-0 z-[65] flex items-center justify-center bg-[#f4eeff]/92 p-4 md:bg-[#f4eeff]/78 md:backdrop-blur-md lg:left-[20rem]">
           <div role="status" aria-live="polite" className="w-full max-w-md">
             <SnapProcessingCard
               status={scanStatus}


### PR DESCRIPTION
### Motivation
- Mobile browsers were showing visual flicker/tearing when the full-screen scan overlay combined `backdrop-filter` blur with continuously animated layers (scan line, floating chips, scanning bar), so the upload/snap flow coming from `/chat` was unstable.
- The goal is to preserve the desktop blurred overlay UX while reducing GPU/compositing instability on smaller screens.

### Description
- Adjusted the full-screen scan overlay in `src/components/Dashboard.tsx` to disable `backdrop-blur` on mobile and apply it only at `md+` breakpoints by switching from `backdrop-blur-md` to `md:backdrop-blur-md` and increasing the mobile background opacity from `bg-[#f4eeff]/78` to `bg-[#f4eeff]/92`.
- This change keeps the same `SnapProcessingCard` placement and behavior while reducing the chance of flicker on mobile devices.

### Testing
- Ran `npx biome lint src/components/Dashboard.tsx` which completed successfully for the touched file.
- Ran the repo-level lint via `npm run lint -- src/components/Dashboard.tsx` which surfaced existing unrelated diagnostics elsewhere in the repo and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0517fcc610832cbf20eb399b86dafd)