### PR TITLE
Preserve `returnTo` for snap uploads and surface scan failures in Chat

### DIFF
--- a/src/app/chat/ConciergeChatClient.tsx
+++ b/src/app/chat/ConciergeChatClient.tsx
@@ -1180,6 +1180,31 @@ export default function ConciergeChatClient({ userInitials = null }: ConciergeCh
   const [rsvpPreview, setRsvpPreview] = useState<RsvpPreviewState>(EMPTY_RSVP_PREVIEW);
   const [weatherContext, setWeatherContext] = useState<ConciergeWeatherContext | null>(null);
   const [isReadyChatComposerOpen, setIsReadyChatComposerOpen] = useState(false);
+  const scanStatusFromQuery = searchParams.get("scanStatus");
+  const scanErrorFromQuery = searchParams.get("scanError");
+
+  useEffect(() => {
+    if (!scanStatusFromQuery) return;
+    if (scanStatusFromQuery === "failed") {
+      const errorMessage =
+        typeof scanErrorFromQuery === "string" && scanErrorFromQuery.trim()
+          ? scanErrorFromQuery
+          : "Upload scan failed before event creation. Please try again.";
+      setError(errorMessage);
+      setMessages((prev) => [
+        ...prev,
+        newMessage(
+          "assistant",
+          "I couldn't finish creating your event from that upload. Please retry or upload a clearer image.",
+        ),
+      ]);
+    }
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete("scanStatus");
+    next.delete("scanError");
+    const query = next.toString();
+    router.replace(query ? `/chat?${query}` : "/chat");
+  }, [router, scanErrorFromQuery, scanStatusFromQuery, searchParams]);
 
   const isGeneratingCard = phase === "generating_card";
   const isPublishingCard = phase === "publishing_card";
@@ -2074,7 +2099,8 @@ export default function ConciergeChatClient({ userInitials = null }: ConciergeCh
           "I'll open the upload scanner so Envitefy can read this file and bring the details back into your event flow.",
         ),
       ]);
-      router.push("/?action=upload");
+      const returnTo = encodeURIComponent("/chat");
+      router.push(`/?action=upload&returnTo=${returnTo}`);
       didRoute = true;
     } catch (err) {
       reportClientLog({

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -284,6 +284,7 @@ export default function Dashboard({
   const cancelledByUserRef = useRef(false);
   const isSubmittingRef = useRef(false);
   const activeScanAttemptIdRef = useRef<string | null>(null);
+  const uploadReturnToRef = useRef<string | null>(null);
   const objectPreviewUrlRef = useRef<string | null>(null);
   const submitScannedEventRef = useRef<(params: SubmitScannedEventParams) => Promise<boolean>>(
     async () => false,
@@ -1345,11 +1346,17 @@ export default function Dashboard({
       try {
         const params = new URLSearchParams(window.location.search);
         const action = (params.get("action") || "").toLowerCase();
+        const returnTo =
+          typeof params.get("returnTo") === "string" && params.get("returnTo")
+            ? params.get("returnTo")
+            : null;
+        uploadReturnToRef.current = returnTo;
         if (!action) return;
         const cleanup = () => {
           try {
             const url = new URL(window.location.href);
             url.searchParams.delete("action");
+            url.searchParams.delete("returnTo");
             window.history.replaceState({}, "", url.toString());
           } catch {
             // noop
@@ -1777,6 +1784,15 @@ export default function Dashboard({
           ocrMeta,
         });
         if (!saveResult.ok) {
+          if (uploadReturnToRef.current === "/chat") {
+            const qs = new URLSearchParams({
+              scanStatus: "failed",
+              scanError:
+                saveResult.error || "We couldn't save this event to your account. Please try again.",
+            });
+            router.push(`/chat?${qs.toString()}`);
+            return false;
+          }
           setError(
             saveResult.error === "Unable to resolve signed-in account"
               ? "We couldn't verify your signed-in account. Sign out and sign back in, then try again."


### PR DESCRIPTION
### Motivation
- Enable the snap upload flow to return users back to the chat UI with a clear error state when scan/save fails, so users get feedback and can retry without losing context.
- Ensure the upload flow can indicate failure via query params (`scanStatus`/`scanError`) and that those params are consumed and cleared from the URL.

### Description
- Read `scanStatus` and `scanError` from query params in `ConciergeChatClient` and show an assistant message and call `setError` when `scanStatus === "failed"`, then remove the query params via `router.replace`.
- When routing to the upload scanner from `ConciergeChatClient`, include a `returnTo=/chat` query param so the upload flow knows where to return after processing.
- Add `uploadReturnToRef` in `Dashboard` to capture and persist a `returnTo` param parsed from the URL and remove it from the browser history.
- If `saveToEnvitefyHistory` fails during scanned event submission and `uploadReturnToRef.current === "/chat"`, redirect to `/chat` with `scanStatus=failed` and `scanError` instead of setting an in-place error, preserving the intended return flow.

### Testing
- Ran TypeScript compilation and a local build (`yarn build`), which completed successfully.
- Ran the existing frontend unit test suite (`yarn test`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a051859f528832cadc97c0dda998a03)