### PR TITLE
Return upload flow to chat and surface scan failures via query params

### DIFF
--- a/src/app/chat/ConciergeChatClient.tsx
+++ b/src/app/chat/ConciergeChatClient.tsx
@@ -1180,6 +1180,31 @@ export default function ConciergeChatClient({ userInitials = null }: ConciergeCh
   const [rsvpPreview, setRsvpPreview] = useState<RsvpPreviewState>(EMPTY_RSVP_PREVIEW);
   const [weatherContext, setWeatherContext] = useState<ConciergeWeatherContext | null>(null);
   const [isReadyChatComposerOpen, setIsReadyChatComposerOpen] = useState(false);
+  const scanStatusFromQuery = searchParams.get("scanStatus");
+  const scanErrorFromQuery = searchParams.get("scanError");
+
+  useEffect(() => {
+    if (!scanStatusFromQuery) return;
+    if (scanStatusFromQuery === "failed") {
+      const errorMessage =
+        typeof scanErrorFromQuery === "string" && scanErrorFromQuery.trim()
+          ? scanErrorFromQuery
+          : "Upload scan failed before event creation. Please try again.";
+      setError(errorMessage);
+      setMessages((prev) => [
+        ...prev,
+        newMessage(
+          "assistant",
+          "I couldn't finish creating your event from that upload. Please retry or upload a clearer image.",
+        ),
+      ]);
+    }
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete("scanStatus");
+    next.delete("scanError");
+    const query = next.toString();
+    router.replace(query ? `/chat?${query}` : "/chat");
+  }, [router, scanErrorFromQuery, scanStatusFromQuery, searchParams]);
 
   const isGeneratingCard = phase === "generating_card";
   const isPublishingCard = phase === "publishing_card";
@@ -2074,7 +2099,8 @@ export default function ConciergeChatClient({ userInitials = null }: ConciergeCh
           "I'll open the upload scanner so Envitefy can read this file and bring the details back into your event flow.",
         ),
       ]);
-      router.push("/?action=upload");
+      const returnTo = encodeURIComponent("/chat");
+      router.push(`/?action=upload&returnTo=${returnTo}`);
       didRoute = true;
     } catch (err) {
       reportClientLog({

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -284,6 +284,7 @@ export default function Dashboard({
   const cancelledByUserRef = useRef(false);
   const isSubmittingRef = useRef(false);
   const activeScanAttemptIdRef = useRef<string | null>(null);
+  const uploadReturnToRef = useRef<string | null>(null);
   const objectPreviewUrlRef = useRef<string | null>(null);
   const submitScannedEventRef = useRef<(params: SubmitScannedEventParams) => Promise<boolean>>(
     async () => false,
@@ -341,6 +342,19 @@ export default function Dashboard({
       objectPreviewUrlRef.current = null;
     }
   }, []);
+
+  const handleSnapFailureForChatReturn = useCallback(
+    (message: string) => {
+      if (uploadReturnToRef.current !== "/chat") return false;
+      const qs = new URLSearchParams({
+        scanStatus: "failed",
+        scanError: message || "Upload scan failed before event creation. Please try again.",
+      });
+      router.push(`/chat?${qs.toString()}`);
+      return true;
+    },
+    [router],
+  );
 
   useEffect(() => {
     return () => {
@@ -913,6 +927,10 @@ export default function Dashboard({
 
       const validationError = validateClientUploadFile(incoming, "attachment");
       if (validationError) {
+        if (handleSnapFailureForChatReturn(validationError)) {
+          setLoading(false);
+          return;
+        }
         setError(validationError);
         logUploadIssue(new Error(validationError), "client-validation", {
           fileName: incoming.name,
@@ -1233,9 +1251,23 @@ export default function Dashboard({
             },
           });
           if (!created) {
+            if (
+              handleSnapFailureForChatReturn(
+                "Unable to create an event from this scan. Please try again.",
+              )
+            ) {
+              return;
+            }
             resetScanUi();
           }
         } else {
+          if (
+            handleSnapFailureForChatReturn(
+              "Unable to create an event from this scan. Please try again.",
+            )
+          ) {
+            return;
+          }
           resetScanUi();
           setError("Unable to create an event from this scan. Please try again.");
         }
@@ -1257,8 +1289,14 @@ export default function Dashboard({
           });
         }
         if (err instanceof Error) {
+          if (handleSnapFailureForChatReturn(err.message)) {
+            return;
+          }
           setError(err.message);
         } else {
+          if (handleSnapFailureForChatReturn("Failed to scan file. Please try again.")) {
+            return;
+          }
           setError("Failed to scan file. Please try again.");
         }
       } finally {
@@ -1267,7 +1305,7 @@ export default function Dashboard({
         setLoading(false);
       }
     },
-    [finishScanUi, logUploadIssue, resetScanUi],
+    [finishScanUi, handleSnapFailureForChatReturn, logUploadIssue, resetScanUi],
   );
 
   const onFile = useCallback(
@@ -1345,11 +1383,17 @@ export default function Dashboard({
       try {
         const params = new URLSearchParams(window.location.search);
         const action = (params.get("action") || "").toLowerCase();
+        const returnTo =
+          typeof params.get("returnTo") === "string" && params.get("returnTo")
+            ? params.get("returnTo")
+            : null;
+        uploadReturnToRef.current = returnTo;
         if (!action) return;
         const cleanup = () => {
           try {
             const url = new URL(window.location.href);
             url.searchParams.delete("action");
+            url.searchParams.delete("returnTo");
             window.history.replaceState({}, "", url.toString());
           } catch {
             // noop
@@ -1765,6 +1809,9 @@ export default function Dashboard({
       try {
         const ready = buildSubmissionEvent(eventInput);
         if (!ready) {
+          if (handleSnapFailureForChatReturn("Missing start time for event creation")) {
+            return false;
+          }
           setError("Missing start time for event creation");
           return false;
         }
@@ -1777,6 +1824,13 @@ export default function Dashboard({
           ocrMeta,
         });
         if (!saveResult.ok) {
+          if (
+            handleSnapFailureForChatReturn(
+              saveResult.error || "We couldn't save this event to your account. Please try again.",
+            )
+          ) {
+            return false;
+          }
           setError(
             saveResult.error === "Unable to resolve signed-in account"
               ? "We couldn't verify your signed-in account. Sign out and sign back in, then try again."
@@ -1807,7 +1861,7 @@ export default function Dashboard({
         isSubmittingRef.current = false;
       }
     },
-    [buildSubmissionEvent, router, saveToEnvitefyHistory],
+    [buildSubmissionEvent, handleSnapFailureForChatReturn, router, saveToEnvitefyHistory],
   );
 
   submitScannedEventRef.current = submitScannedEvent;


### PR DESCRIPTION
### Motivation

- Surface snap upload/scan failures back in the chat UI so users returning from the upload scanner see a helpful error and assistant message. 
- Allow the upload/camera flow to remember where to return (`/chat`) after scanning so failures can be routed to the appropriate page. 
- Centralize logic to redirect back to chat with `scanStatus`/`scanError` to avoid duplicating error-handling UI across the upload flow.

### Description

- Updated `ConciergeChatClient` to read `scanStatus` and `scanError` from the query string and show an error and assistant message when `scanStatus=failed`, then remove those query params via `router.replace` after handling.  
- Changed the upload navigation from `router.push("/?action=upload")` to include a `returnTo=/chat` parameter when starting the scanner.  
- Added `uploadReturnToRef` and parsing of a `returnTo` query param in `Dashboard`, and cleaned the param from the URL after reading.  
- Implemented `handleSnapFailureForChatReturn` in `Dashboard` to redirect back to `/chat` with `scanStatus=failed` and `scanError` when appropriate, and invoked it from validation and error branches in `ingest`, `submitScannedEvent`, and other upload error paths. 
- Wired the new handler into relevant `useCallback` dependencies and ensured upload state is reset or short-circuited when redirecting back to chat.

### Testing

- Ran the TypeScript build (`yarn build`) and it completed successfully.  
- Executed linting (`yarn lint`) with no new errors.  
- Ran the test suite (`yarn test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a051859f528832cadc97c0dda998a03)