### PR TITLE
Fix live-card close button overlap on mobile

### DIFF
--- a/src/components/studio/SharedStudioCardPage.tsx
+++ b/src/components/studio/SharedStudioCardPage.tsx
@@ -114,6 +114,10 @@ export default function SharedStudioCardPage(props: SharedStudioCardProps) {
   const invitationData = props.invitationData || null;
   const posterFirstHeroCard = isPosterFirstHeroCard(invitationData);
 
+  const closeButtonLeft = posterFirstHeroCard
+    ? "calc(50vw + min(calc(100vw - 2rem), calc((100dvh - 6.5rem - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 2 / 3)) / 2 + 0.75rem)"
+    : "calc(50vw + min(calc(100vw - 2rem), calc((100dvh - 6.5rem - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 9 / 16)) / 2 + 0.75rem)";
+
   return (
     <div className="relative flex min-h-[100dvh] w-full flex-col bg-neutral-950">
       {props.celebrationKind ? <EventCelebrationOverlay kind={props.celebrationKind} /> : null}
@@ -121,7 +125,8 @@ export default function SharedStudioCardPage(props: SharedStudioCardProps) {
         <Link
           href={props.returnHref}
           aria-label="Close preview"
-          className="fixed right-4 top-[calc(var(--app-mobile-topbar-offset,4rem)+0.75rem)] z-[7001] inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/70 bg-white/92 text-slate-950 shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition hover:bg-white lg:right-auto lg:left-[calc(20rem+(100vw-20rem)/2+min(calc(100vw-2rem),calc((100dvh-6.5rem-env(safe-area-inset-top,0px)-env(safe-area-inset-bottom,0px))*2/3))/2+0.75rem)] lg:top-[max(1rem,env(safe-area-inset-top))]"
+          className="fixed top-[calc(var(--app-mobile-topbar-offset,4rem)+0.75rem)] z-[7001] inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/70 bg-white/92 text-slate-950 shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition hover:bg-white lg:top-[max(1rem,env(safe-area-inset-top))]"
+          style={{ left: closeButtonLeft }}
         >
           <X size={18} aria-hidden="true" />
         </Link>


### PR DESCRIPTION
### Motivation
- The close button for shared live cards was pinned to the viewport right edge and could overlap the card’s share action on iOS Safari, making the share button inaccessible; the close control should sit outside the card frame.

### Description
- Compute a horizontal offset (`closeButtonLeft`) based on the card’s rendered width and format (poster-first 2:3 vs standard 9:16) to place the close button just outside the card edge.
- Replace the previous fixed `right` anchor with a `left` style computed from `closeButtonLeft` while preserving the existing top safe-area positioning.
- Change only `src/components/studio/SharedStudioCardPage.tsx` to apply the new layout logic.

### Testing
- Ran `npx biome lint src/components/studio/SharedStudioCardPage.tsx`, which completed successfully for the touched file.
- Running the repo-wide `npm run lint -- src/components/studio/SharedStudioCardPage.tsx` surfaced unrelated pre-existing lint errors in other files and therefore failed, but the file-specific lint check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b77b66448832cba36f5bd8160abad)