### PR TITLE
Fix mobile close button position on shared card page

### DIFF
--- a/src/components/studio/SharedStudioCardPage.tsx
+++ b/src/components/studio/SharedStudioCardPage.tsx
@@ -114,10 +114,6 @@ export default function SharedStudioCardPage(props: SharedStudioCardProps) {
   const invitationData = props.invitationData || null;
   const posterFirstHeroCard = isPosterFirstHeroCard(invitationData);
 
-  const closeButtonLeft = posterFirstHeroCard
-    ? "calc(50vw + min(calc(100vw - 2rem), calc((100dvh - 6.5rem - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 2 / 3)) / 2 + 0.75rem)"
-    : "calc(50vw + min(calc(100vw - 2rem), calc((100dvh - 6.5rem - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 9 / 16)) / 2 + 0.75rem)";
-
   return (
     <div className="relative flex min-h-[100dvh] w-full flex-col bg-neutral-950">
       {props.celebrationKind ? <EventCelebrationOverlay kind={props.celebrationKind} /> : null}
@@ -125,8 +121,7 @@ export default function SharedStudioCardPage(props: SharedStudioCardProps) {
         <Link
           href={props.returnHref}
           aria-label="Close preview"
-          className="fixed top-[calc(var(--app-mobile-topbar-offset,4rem)+0.75rem)] z-[7001] inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/70 bg-white/92 text-slate-950 shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition hover:bg-white lg:top-[max(1rem,env(safe-area-inset-top))]"
-          style={{ left: closeButtonLeft }}
+          className="fixed right-[max(0.75rem,env(safe-area-inset-right))] top-[max(calc(var(--app-mobile-topbar-offset,4rem)+0.75rem),calc(env(safe-area-inset-top)+0.75rem))] z-[7001] inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/70 bg-white/92 text-slate-950 shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition hover:bg-white lg:top-[max(1rem,env(safe-area-inset-top))]"
         >
           <X size={18} aria-hidden="true" />
         </Link>


### PR DESCRIPTION
### Motivation
- The close control for the shared card preview could be pushed off-screen on narrow viewports (notably Chrome on Android) because it used a computed `left` value based on the card width and viewport, so it needed a safer, viewport-anchored placement.

### Description
- Replace the computed `closeButtonLeft` positioning with a safe-area-aware fixed `right`/`top` anchor in `src/components/studio/SharedStudioCardPage.tsx` and remove the unused `closeButtonLeft` calculation so the close button remains visible on mobile.

### Testing
- Ran `npm run lint -- src/components/studio/SharedStudioCardPage.tsx`; the lint job ran but exited non-zero due to pre-existing repo-wide Biome lint issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7d149994832ca73082dd2eb4711d)