### PR TITLE
Move live card close button above card

### DIFF
--- a/src/components/studio/SharedStudioCardPage.tsx
+++ b/src/components/studio/SharedStudioCardPage.tsx
@@ -134,7 +134,7 @@ export default function SharedStudioCardPage(props: SharedStudioCardProps) {
         type="button"
         onClick={handleClose}
         aria-label="Close preview"
-        className="fixed right-[max(0.75rem,env(safe-area-inset-right))] top-[max(calc(var(--app-mobile-topbar-offset,4rem)+0.75rem),calc(env(safe-area-inset-top)+0.75rem))] z-[7001] inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/70 bg-white/92 text-slate-950 shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition hover:bg-white lg:left-[calc(20rem+1rem)] lg:right-auto lg:top-[max(1rem,env(safe-area-inset-top))]"
+        className="fixed right-[max(0.75rem,env(safe-area-inset-right))] top-[max(0.75rem,calc(env(safe-area-inset-top)+0.75rem))] z-[7001] inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/70 bg-white/92 text-slate-950 shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition hover:bg-white lg:left-[calc(20rem+1rem)] lg:right-auto lg:top-[max(1rem,env(safe-area-inset-top))]"
       >
         <X size={18} aria-hidden="true" />
       </button>


### PR DESCRIPTION
### Motivation
- Ensure the live card close button sits near the viewport safe area on mobile so it does not overlap or sit inside the card visual by removing the app mobile-topbar offset from its fixed `top` placement.

### Description
- Adjusted the close button `className` in `src/components/studio/SharedStudioCardPage.tsx` to change the `top` calc from `max(calc(var(--app-mobile-topbar-offset,4rem)+0.75rem),calc(env(safe-area-inset-top)+0.75rem))` to `max(0.75rem,calc(env(safe-area-inset-top)+0.75rem))` so the button is positioned above the card on mobile.

### Testing
- Ran `npx biome lint src/components/studio/SharedStudioCardPage.tsx`, which passed for the touched file. 
- Performed a quick HTTP smoke check with `curl -I http://localhost:3000/showcase/lara-s-7th-dino-quest`, which returned `200 OK`.
- Attempted a Playwright screenshot run, but `npx playwright install chromium` failed due to Playwright CDN `403 Forbidden`, so visual verification could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b90bef6d8832c8659130465478e69)