### PR TITLE
Fix mobile footer white gap on event pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1250,6 +1250,7 @@ h5 {
 @layer utilities {
   .event-modern-page {
     min-height: 100vh;
+    min-height: 100dvh;
     background:
       radial-gradient(1200px 520px at 8% -10%, rgba(14, 165, 233, 0.12), transparent 62%),
       radial-gradient(900px 420px at 100% 0%, rgba(245, 158, 11, 0.1), transparent 64%),


### PR DESCRIPTION
### Motivation
- Mobile browsers with dynamic viewport chrome can shrink the visible viewport while scrolling which caused the event page background to stop short and show a white bar at the footer, so the page needs to use the dynamic viewport height to keep the gradient covering the full visible area.

### Description
- Add `min-height: 100dvh` to `.event-modern-page` in `src/app/globals.css` (keeps `min-height: 100vh` for compatibility) so the page background follows the dynamic viewport height.

### Testing
- Ran `git diff --check` and `git status --short` to validate the change and confirmed only `src/app/globals.css` was modified and there were no diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c572ea8f4832cb097d3da233e3e51)