### PR TITLE
Match mobile browser chrome to site background (pink top / purple bottom)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,6 +18,14 @@
 }
 
 :root {
+  --mobile-chrome-top: #f7e4f7;
+  --mobile-chrome-bottom: #8d7be9;
+  --mobile-browser-surface-gradient: linear-gradient(
+    180deg,
+    var(--mobile-chrome-top) 0%,
+    #f8f5ff 40%,
+    var(--mobile-chrome-bottom) 100%
+  );
   --envitefy-project-background: radial-gradient(125% 125% at 50% 10%, #fff 40%, #6366f1 100%);
   --background: #f8f5ff;
   --surface: #fbf7f2;
@@ -624,7 +632,8 @@ html {
   min-height: 100vh;
   min-height: 100dvh;
   /* Extend background to cover status bar area on iOS */
-  background-color: #ffffff;
+  background-color: var(--mobile-chrome-top);
+  background-image: var(--mobile-browser-surface-gradient);
   /* Ensure html extends edge-to-edge */
   margin: 0;
   padding: 0;
@@ -643,7 +652,9 @@ body.embedded-editor {
 }
 
 body {
-  background-color: #ffffff;
+  background-color: transparent;
+  background-image: var(--mobile-browser-surface-gradient);
+  background-attachment: fixed;
   color: var(--foreground);
   font-family:
     var(--font-raleway), var(--font-sans), "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",


### PR DESCRIPTION
### Motivation
- Prevent mobile browser UI areas (status bar / URL bar / bottom chrome) from appearing as a default black band and make them blend with the site visual treatment. 
- Ensure the document-level background works edge-to-edge on mobile (Chrome / Safari) when `viewport-fit: cover` is used.

### Description
- Added new CSS variables `--mobile-chrome-top`, `--mobile-chrome-bottom`, and `--mobile-browser-surface-gradient` in `src/app/globals.css` to define the top (pink) and bottom (purple) chromes and a shared gradient. 
- Applied the gradient to `html` via `background-color` and `background-image` so the top/status area inherits the pinkish color instead of a solid black. 
- Applied the same gradient to `body` (with `background-color: transparent` and `background-attachment: fixed`) so scrolling/viewport changes keep the edge areas visually consistent.

### Testing
- Ran `npm run lint -- src/app/globals.css` which invokes the repo linter; the command exited with lint failures caused by pre-existing repository-wide issues, not this CSS change. 
- No new targeted CSS errors were introduced by the update to `src/app/globals.css` based on the lint output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c6079d938832c9fba164d8101a029)