### PR TITLE
Use page background tint as event theme-color fallback to match mobile browser chrome

### DIFF
--- a/src/lib/theme-color.ts
+++ b/src/lib/theme-color.ts
@@ -1,7 +1,9 @@
 const BRAND_THEME_COLOR = "#7F67D3";
 const BRAND_BACKGROUND_COLOR = "#F8F5FF";
 const GYMNASTICS_THEME_COLOR = "#7C5CDB";
-const EVENT_THEME_COLOR_FALLBACK = BRAND_THEME_COLOR;
+// Use the event-page background tint so mobile browser top chrome matches
+// the page surface instead of defaulting to dark/black UI bars.
+const EVENT_THEME_COLOR_FALLBACK = BRAND_BACKGROUND_COLOR;
 
 export type ThemeColorSource = "route" | "hero" | "event" | "default";
 


### PR DESCRIPTION
### Motivation
- Ensure mobile browser chrome (top and bottom UI areas on Chrome, Safari, etc.) matches the page surface on event pages so the browser bars do not fall back to an OS default dark/black color.

### Description
- Replace the event-route theme-color fallback to use the page background tint by changing `EVENT_THEME_COLOR_FALLBACK` from `BRAND_THEME_COLOR` to `BRAND_BACKGROUND_COLOR` in `src/lib/theme-color.ts`, and add a short comment explaining the intent.

### Testing
- Ran `npm run lint -- src/lib/theme-color.ts`, which surfaced unrelated, repo-wide Biome lint issues (the lint step runs across the repo); no new unit tests were added and no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c67899e2c832c90f4dfd2b3da8016)