### PR TITLE
Make viewport themeColor responsive for mobile and desktop

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -111,7 +111,10 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: themeColorPalette.brand,
+  themeColor: [
+    { media: "(max-width: 767px)", color: themeColorPalette.brand },
+    { color: "#FFFFFF" },
+  ],
 };
 
 export default async function RootLayout({


### PR DESCRIPTION
### Motivation
- Provide a responsive `viewport.themeColor` so mobile browsers use `themeColorPalette.brand` while larger viewports fall back to white to better control address-bar / UI coloring.

### Description
- Replace the single `viewport.themeColor` value with an array of objects in `src/app/layout.tsx`, adding `{ media: "(max-width: 767px)", color: themeColorPalette.brand }` and a default `{ color: "#FFFFFF" }`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c6a4d4c80832c83f3748d56b6e55b)