### PR TITLE
Match mobile browser chrome color to app background

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -112,7 +112,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   viewportFit: "cover",
   themeColor: [
-    { media: "(max-width: 767px)", color: themeColorPalette.brand },
+    { media: "(max-width: 767px)", color: themeColorPalette.background },
     { color: "#FFFFFF" },
   ],
 };


### PR DESCRIPTION
### Motivation
- Mobile browser chrome (address/status bar) was using the brand color which visually conflicted with the app page surface, so the chrome tint should match the page background purple.

### Description
- Replace the mobile viewport `themeColor` entry from `themeColorPalette.brand` to `themeColorPalette.background` in `src/app/layout.tsx` as a single-line metadata update.
- This change targets viewport media `(max-width: 767px)` so mobile UI chrome matches the app background color.

### Testing
- Ran `npm run lint -- src/app/layout.tsx`, which failed due to pre-existing repository-wide Biome lint issues unrelated to this one-line change.
- Verified the diff and file `src/app/layout.tsx` contain only the intended one-line metadata swap and no other edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7588bb7c832c958915e2d14f8c28)