### PR TITLE
Adjust installed app chrome colors for mobile

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -112,7 +112,8 @@ export const viewport: Viewport = {
   initialScale: 1,
   viewportFit: "cover",
   themeColor: [
-    { media: "(max-width: 767px)", color: themeColorPalette.background },
+    { media: "(prefers-color-scheme: light)", color: "#FFFFFF" },
+    { media: "(prefers-color-scheme: dark)", color: themeColorPalette.background },
     { color: "#FFFFFF" },
   ],
 };


### PR DESCRIPTION
### Motivation
- Ensure installed PWA chrome shows a white top bar in light mode while preserving the brand/background color for dark-mode/system surfaces because the previous mobile-width rule forced a pink top bar.

### Description
- Update `viewport.themeColor` in `src/app/layout.tsx` to replace the `(max-width: 767px)` rule with `prefers-color-scheme` rules that set `#FFFFFF` for light mode, `themeColorPalette.background` for dark mode, and keep a `#FFFFFF` fallback.

### Testing
- Ran `node --test src/app/layout.pwa-metadata.source.test.mjs` and the test suite passed (3 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c872d8954832cb500aba2f89b5126)