### PR TITLE
Allow signup from envitefy.com without source-cookie gating

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -87,16 +87,9 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Email and password are required" }, { status: 400 });
     }
 
-    if (!cookieSignupSource) {
+    if (requestedSignupSource && cookieSignupSource && requestedSignupSource !== cookieSignupSource) {
       return NextResponse.json(
-        { error: "Create accounts only from /snap or /gymnastics." },
-        { status: 400 },
-      );
-    }
-
-    if (requestedSignupSource && requestedSignupSource !== cookieSignupSource) {
-      return NextResponse.json(
-        { error: "Signup source mismatch. Restart from /snap or /gymnastics." },
+        { error: "Signup source mismatch. Please refresh and try again." },
         { status: 400 },
       );
     }
@@ -119,12 +112,14 @@ export async function POST(req: Request) {
       });
     }
 
+    const effectiveSignupSource = cookieSignupSource ?? requestedSignupSource ?? "snap";
+
     await createUserWithEmailPassword({
       email,
       password,
       firstName,
       lastName,
-      signupSource: cookieSignupSource,
+      signupSource: effectiveSignupSource,
     });
     const response = NextResponse.json({ ok: true });
     response.cookies.set("envitefy_signup_source", "", {


### PR DESCRIPTION
### Motivation
- Enable users to create accounts directly from the main marketing site (`envitefy.com`) without requiring the `envitefy_signup_source` cookie to be present, reducing signup friction while still protecting against explicit source mismatches.
- The primary intent is to accept signups coming from landing/auth flows (e.g. modal or `/landing`) while preserving product-scoped attribution when available.

### Description
- Relaxed the strict cookie gating in `src/app/api/auth/signup/route.ts` by removing the hard rejection when `envitefy_signup_source` is missing.  
- Changed the mismatch check so it only errors when both the request `signupSource` and cookie source exist and disagree.  
- Introduced `effectiveSignupSource = cookieSignupSource ?? requestedSignupSource ?? "snap"` and pass it into `createUserWithEmailPassword` so new accounts always get a valid `primary_signup_source`.  
- Reworded the mismatch error to a generic guidance message (`"Signup source mismatch. Please refresh and try again."`).

### Testing
- Ran the targeted test `node --test src/app/api/auth/signup-source/route.test.mjs`, which reported 1 pass and 1 fail (the failing assertion is a source-shape / component-string check in `SignupForm.tsx` unrelated to runtime signup behavior).  
- Lint (`npm run -s lint -- src/app/api/auth/signup/route.ts`) was not executed in the same command chain because the test step failed first.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb1ad2870832c8f14b0ab9f0b080d)