### PR TITLE
Fix signed-out mobile landing navigation

### DIFF
--- a/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
+++ b/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
@@ -103,3 +103,25 @@ test("HeroTopNav keeps desktop auth actions while using inline login inside the 
   assert.match(source, /\) : showMobileGuestActions \? \(\s*<button/s);
   assert.match(source, /onClick=\{onGuestLoginAction\}/);
 });
+
+test("HeroTopNav mobile hash links close without active styling or scroll restoration", () => {
+  const source = readSource("src/components/navigation/HeroTopNav.tsx");
+
+  assert.match(source, /const pendingHashScrollTopRef = useRef<number \| null>\(null\);/);
+  assert.match(source, /const pendingHashScrollTop = pendingHashScrollTopRef\.current;/);
+  assert.match(source, /pendingHashScrollTopRef\.current = targetTop;/);
+  assert.match(
+    source,
+    /if \(closeMobileMenu\) \{\s*pendingHashScrollTopRef\.current = targetTop;\s*setMobileMenuOpen\(false\);\s*return;\s*\}/s,
+  );
+
+  const mobileNavStart = source.lastIndexOf('aria-label="Hero navigation"');
+  const mobileNavBlock = source.slice(
+    mobileNavStart,
+    source.indexOf('{status === "authenticated" ? (', mobileNavStart),
+  );
+
+  assert.match(mobileNavBlock, /ariaCurrent=\{undefined\}/);
+  assert.doesNotMatch(mobileNavBlock, /activeNavHref === link\.href/);
+  assert.doesNotMatch(mobileNavBlock, /nav-chrome-pill-active/);
+});

--- a/src/components/navigation/HeroTopNav.tsx
+++ b/src/components/navigation/HeroTopNav.tsx
@@ -106,6 +106,7 @@ export default function HeroTopNav({
   const mobileMenuToggleRef = useRef<HTMLButtonElement | null>(null);
   const mobileMenuDragStartX = useRef<number | null>(null);
   const mobileMenuSwipeStartX = useRef<number | null>(null);
+  const pendingHashScrollTopRef = useRef<number | null>(null);
   const isTransparentDark = variant === "transparent-dark";
   const isDarkGlass = variant === "glass-dark" || isTransparentDark;
   const isTransparentOverHero = isTransparentDark && !hasScrolledPastHero;
@@ -269,7 +270,13 @@ export default function HeroTopNav({
       body.style.left = previousBodyLeft;
       body.style.right = previousBodyRight;
       body.style.width = previousBodyWidth;
-      window.scrollTo(0, scrollY);
+      const pendingHashScrollTop = pendingHashScrollTopRef.current;
+      if (pendingHashScrollTop === null) {
+        window.scrollTo(0, scrollY);
+      } else {
+        pendingHashScrollTopRef.current = null;
+        window.scrollTo(0, pendingHashScrollTop);
+      }
     };
   }, [mobileMenuOpen]);
 
@@ -301,11 +308,6 @@ export default function HeroTopNav({
   const handleHashLinkClick =
     (href: string, closeMobileMenu = false): MouseEventHandler<HTMLAnchorElement> =>
     (event) => {
-      setActiveNavHref(href);
-      if (closeMobileMenu) {
-        setMobileMenuOpen(false);
-      }
-
       const targetId = getHashLinkId(href);
       if (!targetId || typeof window === "undefined") return;
 
@@ -313,9 +315,18 @@ export default function HeroTopNav({
       if (!target) return;
 
       event.preventDefault();
+      const targetTop = target.getBoundingClientRect().top + window.scrollY;
       window.history.pushState(null, "", href);
+
+      if (closeMobileMenu) {
+        pendingHashScrollTopRef.current = targetTop;
+        setMobileMenuOpen(false);
+        return;
+      }
+
+      setActiveNavHref(href);
       window.scrollTo({
-        top: target.getBoundingClientRect().top + window.scrollY,
+        top: targetTop,
         behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
       });
     };
@@ -582,22 +593,17 @@ export default function HeroTopNav({
                     aria-label="Hero navigation"
                   >
                     {navLinks.map((link) => {
-                      const isActive = activeNavHref === link.href;
                       return (
                         <NavLinkItem
                           key={`${link.label}:${link.href}:mobile`}
                           href={link.href}
                           label={link.label}
-                          ariaCurrent={isActive ? "location" : undefined}
+                          ariaCurrent={undefined}
                           className={cx(
                             "nav-chrome-motion w-full rounded-2xl px-4 py-3 text-right text-base font-semibold transition",
                             useDarkMobileMenu
-                              ? isActive
-                                ? "border border-white/22 bg-white/[0.16] text-white shadow-[0_14px_28px_rgba(0,0,0,0.18)]"
-                                : "text-white/74 hover:bg-white/[0.08] hover:text-white"
-                              : isActive
-                                ? "nav-chrome-pill-active"
-                                : lightNavPillClass,
+                              ? "text-white/74 hover:bg-white/[0.08] hover:text-white"
+                              : lightNavPillClass,
                           )}
                           onClick={
                             link.href.startsWith("#")


### PR DESCRIPTION
### Motivation
- The mobile drawer for the landing page showed an active/highlighted tab for signed-out users for hash links and sometimes failed to navigate after tapping a hash link. 
- The root cause was the mobile menu reusing desktop `activeNavHref` state and the body-lock cleanup restoring the previous `scrollY`, which could undo a hash navigation performed while closing the drawer.

### Description
- Stop using the desktop active state inside the mobile drawer by removing `aria-current` and active/highlight classes for mobile menu items so signed-out mobile menu items are never rendered as selected. 
- Add `pendingHashScrollTopRef` and update `handleHashLinkClick` to set a pending scroll target when `closeMobileMenu` is requested, then close the drawer and defer scroll restoration. 
- Update the mobile menu body-lock cleanup to prefer the pending scroll target (if present) instead of always restoring the previous `scrollY`. 
- Add a source-level regression test `src/components/navigation/HeroTopNav.mobile-login.source.test.mjs` that verifies the new mobile behavior and absence of active styling in the mobile drawer.

### Testing
- Ran the source tests with `node --test src/components/navigation/HeroTopNav.mobile-login.source.test.mjs src/app/landing/page.test.mjs` and all tests passed. 
- Ran `npx biome check src/components/navigation/HeroTopNav.tsx src/components/navigation/HeroTopNav.mobile-login.source.test.mjs` and the checks succeeded. 
- Attempted to run Playwright to capture a mobile screenshot, but `npx playwright install chromium` failed due to an external browser download being blocked with HTTP 403, so a browser-based visual test could not be performed in this environment. 
- Attempted to run the local VS Code lint script referenced in the repo, but the script was not present in the container so that check could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cdf51710c832cb821582c326c70b8)