### PR TITLE
Fix mobile landing nav hash scrolling

### DIFF
--- a/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
+++ b/src/components/navigation/HeroTopNav.mobile-login.source.test.mjs
@@ -104,15 +104,16 @@ test("HeroTopNav keeps desktop auth actions while using inline login inside the 
   assert.match(source, /onClick=\{onGuestLoginAction\}/);
 });
 
-test("HeroTopNav mobile hash links close without active styling or scroll restoration", () => {
+test("HeroTopNav mobile hash links close before resolving their target scroll", () => {
   const source = readSource("src/components/navigation/HeroTopNav.tsx");
 
-  assert.match(source, /const pendingHashScrollTopRef = useRef<number \| null>\(null\);/);
-  assert.match(source, /const pendingHashScrollTop = pendingHashScrollTopRef\.current;/);
-  assert.match(source, /pendingHashScrollTopRef\.current = targetTop;/);
+  assert.match(source, /const pendingMobileHashHrefRef = useRef<string \| null>\(null\);/);
+  assert.match(source, /const pendingMobileHashHref = pendingMobileHashHrefRef\.current;/);
+  assert.match(source, /pendingMobileHashHrefRef\.current = href;/);
+  assert.match(source, /const pendingTargetId = getHashLinkId\(pendingMobileHashHref\);/);
   assert.match(
     source,
-    /if \(closeMobileMenu\) \{\s*pendingHashScrollTopRef\.current = targetTop;\s*setMobileMenuOpen\(false\);\s*return;\s*\}/s,
+    /if \(closeMobileMenu\) \{\s*pendingMobileHashHrefRef\.current = href;\s*setMobileMenuOpen\(false\);\s*return;\s*\}/s,
   );
 
   const mobileNavStart = source.lastIndexOf('aria-label="Hero navigation"');

--- a/src/components/navigation/HeroTopNav.tsx
+++ b/src/components/navigation/HeroTopNav.tsx
@@ -106,7 +106,7 @@ export default function HeroTopNav({
   const mobileMenuToggleRef = useRef<HTMLButtonElement | null>(null);
   const mobileMenuDragStartX = useRef<number | null>(null);
   const mobileMenuSwipeStartX = useRef<number | null>(null);
-  const pendingHashScrollTopRef = useRef<number | null>(null);
+  const pendingMobileHashHrefRef = useRef<string | null>(null);
   const isTransparentDark = variant === "transparent-dark";
   const isDarkGlass = variant === "glass-dark" || isTransparentDark;
   const isTransparentOverHero = isTransparentDark && !hasScrolledPastHero;
@@ -270,13 +270,29 @@ export default function HeroTopNav({
       body.style.left = previousBodyLeft;
       body.style.right = previousBodyRight;
       body.style.width = previousBodyWidth;
-      const pendingHashScrollTop = pendingHashScrollTopRef.current;
-      if (pendingHashScrollTop === null) {
+      const pendingMobileHashHref = pendingMobileHashHrefRef.current;
+      pendingMobileHashHrefRef.current = null;
+
+      if (pendingMobileHashHref === null) {
         window.scrollTo(0, scrollY);
-      } else {
-        pendingHashScrollTopRef.current = null;
-        window.scrollTo(0, pendingHashScrollTop);
+        return;
       }
+
+      window.scrollTo(0, scrollY);
+      window.requestAnimationFrame(() => {
+        const pendingTargetId = getHashLinkId(pendingMobileHashHref);
+        const pendingTarget = pendingTargetId ? document.getElementById(pendingTargetId) : null;
+
+        if (!pendingTarget) return;
+
+        setActiveNavHref(pendingMobileHashHref);
+        window.scrollTo({
+          top: pendingTarget.getBoundingClientRect().top + window.scrollY,
+          behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches
+            ? "auto"
+            : "smooth",
+        });
+      });
     };
   }, [mobileMenuOpen]);
 
@@ -315,18 +331,17 @@ export default function HeroTopNav({
       if (!target) return;
 
       event.preventDefault();
-      const targetTop = target.getBoundingClientRect().top + window.scrollY;
       window.history.pushState(null, "", href);
 
       if (closeMobileMenu) {
-        pendingHashScrollTopRef.current = targetTop;
+        pendingMobileHashHrefRef.current = href;
         setMobileMenuOpen(false);
         return;
       }
 
       setActiveNavHref(href);
       window.scrollTo({
-        top: targetTop,
+        top: target.getBoundingClientRect().top + window.scrollY,
         behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
       });
     };


### PR DESCRIPTION
### Motivation
- Mobile top-right landing menu hash links were navigating to the wrong sections because we computed and stored a target scroll position while the body was locked (fixed) by the open mobile menu, leading to stale coordinates after unlock.
- The intent is to ensure tapping a hash link in the mobile menu closes the menu and then reliably scrolls to the correct target section on the page.

### Description
- Replace the stored numeric scroll position with a stored href by adding `pendingMobileHashHrefRef` and setting it when a mobile hash link is clicked with `closeMobileMenu = true`.
- On mobile menu cleanup, restore the previous page scroll first and then, on the next animation frame, resolve the pending href to its DOM element with `getHashLinkId`/`document.getElementById` and call `window.scrollTo` using the fresh bounding rect; also update `setActiveNavHref` accordingly.
- Use immediate `getBoundingClientRect()` for non-mobile-close hash clicks instead of relying on a precomputed value.
- Update the source-guard test `src/components/navigation/HeroTopNav.mobile-login.source.test.mjs` to assert the new deferred-href behavior.
- Files changed: `src/components/navigation/HeroTopNav.tsx` and `src/components/navigation/HeroTopNav.mobile-login.source.test.mjs`.

### Testing
- Ran `npx biome lint src/components/navigation/HeroTopNav.tsx src/components/navigation/HeroTopNav.mobile-login.source.test.mjs` and it completed successfully against the touched files.
- Ran `node --test src/components/navigation/HeroTopNav.mobile-login.source.test.mjs src/app/landing/page.test.mjs` and all tests passed (4 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cf8bfdb04832c896c0ac5381cdb80)