### PR TITLE
Fit landing hero CTAs on mobile

### DIFF
--- a/src/app/landing/LandingExperience.tsx
+++ b/src/app/landing/LandingExperience.tsx
@@ -59,6 +59,7 @@ type HeroProductSlide = {
   desktopImage: string;
   imageAlt: string;
   imagePosition?: string;
+  mobilePrimaryCtaLabel?: string;
 };
 
 const templateProofTiles: ProofTile[] = [
@@ -163,6 +164,7 @@ const heroProductSlides: HeroProductSlide[] = [
     image: "/images/landing/hero/garden-brunch-mobile.webp",
     desktopImage: "/images/landing/hero/garden-brunch-desktop.webp",
     imageAlt: "Garden brunch live invitation card",
+    mobilePrimaryCtaLabel: "Create invite",
   },
   {
     id: "garden-vows",
@@ -172,6 +174,7 @@ const heroProductSlides: HeroProductSlide[] = [
     image: "/images/landing/hero/garden-vows-mobile.webp",
     desktopImage: "/images/landing/hero/garden-vows-desktop.webp",
     imageAlt: "Wedding weekend event page preview",
+    mobilePrimaryCtaLabel: "Create wedding",
   },
   {
     id: "school-trip",
@@ -181,6 +184,7 @@ const heroProductSlides: HeroProductSlide[] = [
     image: "/images/landing/hero/lincoln-discovery-mobile.webp",
     desktopImage: "/images/landing/hero/lincoln-discovery-desktop.webp",
     imageAlt: "School field trip event page preview",
+    mobilePrimaryCtaLabel: "Create trip",
   },
   {
     id: "team-weekend",
@@ -190,6 +194,7 @@ const heroProductSlides: HeroProductSlide[] = [
     image: "/images/landing/hero/friday-night-lights-mobile.webp",
     desktopImage: "/images/landing/hero/friday-night-lights-desktop.webp",
     imageAlt: "Team schedule event page preview",
+    mobilePrimaryCtaLabel: "Create schedule",
   },
   {
     id: "birthday-party",
@@ -199,6 +204,7 @@ const heroProductSlides: HeroProductSlide[] = [
     image: "/images/landing/hero/birthday-dino-mobile.webp",
     desktopImage: "/images/landing/hero/birthday-dino-desktop.webp",
     imageAlt: "Birthday party event page preview",
+    mobilePrimaryCtaLabel: "Create party",
   },
   {
     id: "baby-shower",
@@ -208,6 +214,7 @@ const heroProductSlides: HeroProductSlide[] = [
     image: "/images/landing/hero/baby-shower-mobile.webp",
     desktopImage: "/images/landing/hero/baby-shower-desktop.webp",
     imageAlt: "Baby shower event page preview",
+    mobilePrimaryCtaLabel: "Create shower",
   },
   {
     id: "open-house",
@@ -217,6 +224,7 @@ const heroProductSlides: HeroProductSlide[] = [
     image: "/images/landing/hero/open-house-mobile.webp",
     desktopImage: "/images/landing/hero/open-house-desktop.webp",
     imageAlt: "Open house event page preview",
+    mobilePrimaryCtaLabel: "Let's create",
   },
 ] as const;
 
@@ -926,20 +934,24 @@ function HeroProductCarousel({ onPrimaryAction }: { onPrimaryAction: () => void 
             >
               {activeSlide.description}
             </p>
-            <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+            <div className="mt-9 flex flex-row gap-2 sm:gap-3">
               <button
                 type="button"
                 onClick={onPrimaryAction}
-                className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-white/18 bg-white/14 px-6 text-sm font-semibold text-white shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/22"
+                className="inline-flex h-12 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md border border-white/18 bg-white/14 px-3 text-[13px] font-semibold text-white shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/22 sm:flex-none sm:gap-2 sm:px-6 sm:text-sm"
               >
-                Let's create
-                <ArrowRight className="h-4 w-4" />
+                <span className="truncate sm:hidden">
+                  {activeSlide.mobilePrimaryCtaLabel ?? "Let's create"}
+                </span>
+                <span className="hidden sm:inline">Let's create</span>
+                <ArrowRight className="h-4 w-4 shrink-0" />
               </button>
               <Link
                 href="#showcase"
-                className="inline-flex h-12 items-center justify-center rounded-md border border-white/18 bg-black/18 px-6 text-sm font-semibold text-white backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/14"
+                className="inline-flex h-12 min-w-0 flex-1 items-center justify-center rounded-md border border-white/18 bg-black/18 px-3 text-[13px] font-semibold text-white backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/14 sm:flex-none sm:px-6 sm:text-sm"
               >
-                View live examples
+                <span className="truncate sm:hidden">View examples</span>
+                <span className="hidden sm:inline">View live examples</span>
               </Link>
             </div>
           </motion.div>

--- a/src/app/landing/page.test.mjs
+++ b/src/app/landing/page.test.mjs
@@ -23,6 +23,9 @@ test("landing page is hosted-event-led and premium", () => {
   assert.match(landingExperience, /Beautiful hosted events, from invite to RSVP/);
   assert.match(landingExperience, /Let's create/);
   assert.match(landingExperience, /View live examples/);
+  assert.match(landingExperience, /mobilePrimaryCtaLabel: "Create invite"/);
+  assert.match(landingExperience, /mobilePrimaryCtaLabel: "Create wedding"/);
+  assert.match(landingExperience, /View examples/);
   assert.match(landingExperience, /PremiumLandingHero/);
   assert.match(landingExperience, /GuestActionSuite/);
   assert.match(landingExperience, /TemplateGallery/);
@@ -42,7 +45,10 @@ test("landing page is hosted-event-led and premium", () => {
   assert.match(landingExperience, /hostTestimonials/);
   assert.match(landingExperience, /landingTestimonials/);
   assert.match(landingExperience, /function interleaveTestimonials/);
-  assert.match(landingExperience, /const landingTestimonials: TestimonialItem\[] = interleaveTestimonials\(/);
+  assert.match(
+    landingExperience,
+    /const landingTestimonials: TestimonialItem\[] = interleaveTestimonials\(/,
+  );
   const testimonialSource = landingExperience.slice(
     landingExperience.indexOf("const guestTestimonials"),
     landingExperience.indexOf("const creationPaths"),


### PR DESCRIPTION
### Motivation
- Ensure the two hero CTAs (`Let's create` and `View live examples`) fit on one row on mobile by making the mobile layout compact and truncation-safe. 
- Make the primary CTA more contextual on mobile by allowing a short, slide-specific label while preserving desktop copy. 
- Keep source-shape tests and tooling in sync with copy/layout changes so regressions are caught.

### Description
- Added a mobile-specific CTA label field to the slide type (`HeroProductSlide.mobilePrimaryCtaLabel`) and populated concise labels for each `heroProductSlides` entry. 
- Changed the hero CTA container to a one-row mobile layout and updated button classes for `min-w-0`, equal-width behavior (`flex-1` on mobile), tighter padding/type, and truncation to keep both CTAs side-by-side. 
- Render slide-specific mobile copy via responsive spans so desktop still shows the original `Let's create` and `View live examples` text while mobile shows shorter `Create …` labels and `View examples`. 
- Shortened the mobile secondary CTA to `View examples` and updated the landing source-shape test in `src/app/landing/page.test.mjs` to assert the new mobile strings.

### Testing
- Ran the unit/source-shape tests with `node --test src/app/landing/page.test.mjs` and they passed. 
- Ran targeted formatting with `npx biome format --write src/app/landing/LandingExperience.tsx src/app/landing/page.test.mjs` which completed successfully. 
- Ran targeted lint on the touched files with `npx biome lint src/app/landing/LandingExperience.tsx src/app/landing/page.test.mjs` which completed without errors for those files (note: `npm run lint` / repo-wide lint triggers unrelated existing issues outside the changed files). 
- Attempted to capture a mobile screenshot via Playwright, but `npx playwright install` failed due to a CDN download returning HTTP 403 in this environment, so visual verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da0250f74832cb29dcaf98d577f6c)