### PR TITLE
Fix password reset email links

### DIFF
--- a/src/app/api/auth/forgot/route.ts
+++ b/src/app/api/auth/forgot/route.ts
@@ -3,42 +3,27 @@ import { createPasswordResetToken, getUserByEmail } from "@/lib/db";
 import { sendPasswordResetEmail } from "@/lib/email";
 import { absoluteUrl } from "@/lib/absolute-url";
 import { buildPublicPasswordResetUrl } from "@/lib/auth-reset-url";
-import { createSupabaseRecoveryLink, isSupabaseAuthConfigured } from "@/lib/supabase-auth";
 
 export const runtime = "nodejs";
 
 export async function POST(request: Request) {
   try {
-    const body = await request.json().catch(() => ({} as any));
-    const email = String(body.email || "").trim().toLowerCase();
+    const body = await request.json().catch((): null => null);
+    const email =
+      typeof body === "object" && body !== null && "email" in body
+        ? String(body.email || "")
+            .trim()
+            .toLowerCase()
+        : "";
     if (!email) return NextResponse.json({ error: "Email is required" }, { status: 400 });
 
     // Always respond 200 to prevent user enumeration; but create a token if user exists
     const user = await getUserByEmail(email).catch(() => null);
     if (user) {
-      const fallbackReset = await createPasswordResetToken(email, 30);
-      const fallbackResetUrl = new URL(buildPublicPasswordResetUrl(await absoluteUrl("/reset")));
-      fallbackResetUrl.searchParams.set("token", fallbackReset.token);
-      let resetUrl = fallbackResetUrl.toString();
-      if (isSupabaseAuthConfigured()) {
-        try {
-          const baseResetUrl = await absoluteUrl("/reset");
-          resetUrl = await createSupabaseRecoveryLink({
-            email,
-            baseResetUrl,
-          });
-        } catch (supabaseErr) {
-          try {
-            console.error("[auth/forgot] Supabase recovery link generation failed, using local token", {
-              email,
-              error:
-                supabaseErr instanceof Error
-                  ? supabaseErr.message
-                  : String(supabaseErr),
-            });
-          } catch {}
-        }
-      }
+      const reset = await createPasswordResetToken(email, 30);
+      const resetUrlBuilder = new URL(buildPublicPasswordResetUrl(await absoluteUrl("/reset")));
+      resetUrlBuilder.searchParams.set("token", reset.token);
+      const resetUrl = resetUrlBuilder.toString();
       let emailSent = false;
       try {
         await sendPasswordResetEmail({ toEmail: email, resetUrl });
@@ -47,7 +32,11 @@ export async function POST(request: Request) {
         // In non-production, include URL and error to aid testing if email fails
         const includeLink = process.env.NODE_ENV !== "production";
         const message = err instanceof Error ? err.message : String(err);
-        return NextResponse.json({ ok: true, emailSent: false, ...(includeLink ? { resetUrl, reason: message } : {}) });
+        return NextResponse.json({
+          ok: true,
+          emailSent: false,
+          ...(includeLink ? { resetUrl, reason: message } : {}),
+        });
       }
       return NextResponse.json({ ok: true, emailSent });
     }

--- a/src/app/reset/reset-password.supabase.source.test.mjs
+++ b/src/app/reset/reset-password.supabase.source.test.mjs
@@ -5,16 +5,21 @@ import test from "node:test";
 
 const repoRoot = process.cwd();
 
-const readSource = (relativePath) =>
-  fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+const readSource = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
 
-test("forgot password flow avoids localhost Supabase recovery redirects", () => {
+test("forgot password emails use a first-party public reset URL instead of a Supabase action link", () => {
   const forgotRoute = readSource("src/app/api/auth/forgot/route.ts");
-  const supabaseAuth = readSource("src/lib/supabase-auth.ts");
+  const resetUrlHelpers = readSource("src/lib/auth-reset-url.ts");
+  const publicAssetUrl = readSource("src/lib/public-asset-url.ts");
 
-  assert.match(forgotRoute, /buildPublicPasswordResetUrl\(await absoluteUrl\("\/reset"\)\)/);
-  assert.match(supabaseAuth, /buildSupabasePasswordResetRedirectUrl\(params\.baseResetUrl\)/);
-  assert.match(supabaseAuth, /rewriteSupabaseRecoveryActionLinkRedirect\(link, params\.baseResetUrl\)/);
+  assert.match(
+    forgotRoute,
+    /new URL\(buildPublicPasswordResetUrl\(await absoluteUrl\("\/reset"\)\)\)/,
+  );
+  assert.match(forgotRoute, /resetUrlBuilder\.searchParams\.set\("token", reset\.token\)/);
+  assert.doesNotMatch(forgotRoute, /createSupabaseRecoveryLink/);
+  assert.match(resetUrlHelpers, /new URL\(buildPublicAssetUrl\(baseResetUrl \|\| "\/reset"\)\)/);
+  assert.match(publicAssetUrl, /if \(!origin \|\| isLoopbackHost\(origin\)\) continue;/);
 });
 
 test("reset flow accepts encoded Supabase recovery fragments", () => {


### PR DESCRIPTION
### Motivation

- Password-reset emails were sometimes using Supabase recovery action links which could redirect to loopback origins (e.g. `http://localhost:3000`), causing reset emails to point at local dev hosts instead of a first-party public reset page.

### Description

- Stop generating/using Supabase recovery action links in the forgot-password flow and always build a first-party public reset URL using `buildPublicPasswordResetUrl(await absoluteUrl("/reset"))` with the generated token as a query parameter in `src/app/api/auth/forgot/route.ts`.
- Harden parsing of the request body to avoid runtime errors when `request.json()` returns unexpected values.
- Update the source-level regression guard test to assert the new behavior: the route constructs a `new URL(buildPublicPasswordResetUrl(...))`, sets the `token` query param, and does not call `createSupabaseRecoveryLink`, and to verify public-asset origin loopback filtering in helpers (`src/app/reset/reset-password.supabase.source.test.mjs`).

### Testing

- Ran unit/source-guard tests with `node --test src/app/reset/reset-password.supabase.source.test.mjs src/app/api/auth/reset/route.test.mjs` and both tests passed.
- Ran targeted lint on the modified files with `npx biome lint src/app/api/auth/forgot/route.ts src/app/reset/reset-password.supabase.source.test.mjs` which completed for those files.
- Attempted `npm run lint:vscode -- <files>` but the environment lacks the required Cursor/VS Code helper extension so that step reported an environment limitation (not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f3269d84832c9a1a471d42b20dc3)